### PR TITLE
feat: add sortable and groupable video list

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -28,6 +28,13 @@ import { releaseVideoHandlesForAsync } from "./utils/releaseVideoHandles";
 import useTrashIntegration from "./hooks/actions/useTrashIntegration";
 
 import {
+  SortKey,
+  buildComparator,
+  groupAndSort,
+  buildRandomOrderMap,
+} from "./sorting/sorting.js";
+
+import {
   calculateSafeZoom,
   zoomClassForLevel,
   clampZoomIndex,
@@ -108,6 +115,10 @@ function App() {
   const [maxConcurrentPlaying, setMaxConcurrentPlaying] = useState(250);
   const [zoomLevel, setZoomLevel] = useState(1);
   const [settingsLoaded, setSettingsLoaded] = useState(false);
+  const [sortKey, setSortKey] = useState(SortKey.NAME);
+  const [sortDir, setSortDir] = useState("asc");
+  const [groupByFolders, setGroupByFolders] = useState(true);
+  const [randomSeed, setRandomSeed] = useState(null);
 
   // Loading state
   const [isLoadingFolder, setIsLoadingFolder] = useState(false);
@@ -176,44 +187,53 @@ function App() {
       onOrderChange: setVisualOrderedIds,
     });
 
-  // MEMOIZED grouped & sorted (data order)
-  const groupedAndSortedVideos = useMemo(() => {
-    if (videos.length === 0) return [];
-    const videosByFolder = new Map();
-    videos.forEach((video) => {
-      const folderPath =
-        video.metadata?.folder ||
-        path.dirname(video.fullPath || video.relativePath || "");
-      if (!videosByFolder.has(folderPath)) videosByFolder.set(folderPath, []);
-      videosByFolder.get(folderPath).push(video);
-    });
-    const sortedFolders = Array.from(videosByFolder.keys()).sort();
-    const result = [];
-    sortedFolders.forEach((folderPath) => {
-      const folderVideos = videosByFolder.get(folderPath);
-      folderVideos.sort((a, b) => a.name.localeCompare(b.name));
-      result.push(...folderVideos);
-    });
-    if (__DEV__)
-      console.log(
-        `📁 Grouped ${videos.length} videos into ${sortedFolders.length} folders`
-      );
-    return result;
-  }, [videos]);
+  // MEMOIZED sorting & grouping
+  const randomOrderMap = useMemo(
+    () =>
+      sortKey === SortKey.RANDOM
+        ? buildRandomOrderMap(
+            videos.map((v) => v.id),
+            randomSeed ?? Date.now()
+          )
+        : null,
+    [sortKey, randomSeed, videos]
+  );
+
+  const comparator = useMemo(
+    () => buildComparator({ sortKey, sortDir, randomOrderMap }),
+    [sortKey, sortDir, randomOrderMap]
+  );
+
+  const orderedVideos = useMemo(
+    () => groupAndSort(videos, { groupByFolders, comparator }),
+    [videos, groupByFolders, comparator]
+  );
 
   // data order ids (fallback)
   const orderedIds = useMemo(
-    () => groupedAndSortedVideos.map((v) => v.id),
-    [groupedAndSortedVideos]
+    () => orderedVideos.map((v) => v.id),
+    [orderedVideos]
   );
 
   // Prefer visual order if we have it
   const orderForRange = visualOrderedIds.length ? visualOrderedIds : orderedIds;
 
   const getById = useCallback(
-    (id) => groupedAndSortedVideos.find((v) => v.id === id),
-    [groupedAndSortedVideos]
+    (id) => orderedVideos.find((v) => v.id === id),
+    [orderedVideos]
   );
+
+  const sortStatus = useMemo(() => {
+    const keyLabels = {
+      [SortKey.NAME]: "Name",
+      [SortKey.CREATED]: "Created",
+      [SortKey.RANDOM]: "Random",
+    };
+    const arrow =
+      sortKey === SortKey.RANDOM ? "" : sortDir === "asc" ? "↑" : "↓";
+    const base = `Sorted by ${keyLabels[sortKey]}${arrow ? ` ${arrow}` : ""}`;
+    return groupByFolders ? `${base} • Grouped by folders` : base;
+  }, [sortKey, sortDir, groupByFolders]);
 
   // Simple toast used by actions layer
   const notify = useCallback((message, type = "info") => {
@@ -251,7 +271,7 @@ function App() {
 
   // --- Composite Video Collection Hook ---
   const videoCollection = useVideoCollection({
-    videos: groupedAndSortedVideos,
+    videos: orderedVideos,
     visibleVideos,
     loadedVideos,
     loadingVideos,
@@ -275,7 +295,7 @@ function App() {
     openFullScreen,
     closeFullScreen,
     navigateFullScreen,
-  } = useFullScreenModal(groupedAndSortedVideos, "masonry-vertical", gridRef);
+  } = useFullScreenModal(orderedVideos, "masonry-vertical", gridRef);
 
   const {
     contextMenu,
@@ -346,12 +366,12 @@ function App() {
   );
 
   const getMinimumZoomLevel = useCallback(() => {
-    const videoCount = groupedAndSortedVideos.length;
+    const videoCount = orderedVideos.length;
     const windowWidth = window.innerWidth;
     if (videoCount > 200 && windowWidth > 2560) return 2;
     if (videoCount > 150 && windowWidth > 1920) return 1;
     return 0;
-  }, [groupedAndSortedVideos.length]);
+  }, [orderedVideos.length]);
 
   const handleZoomChangeSafe = useCallback(
     (newZoom) => {
@@ -432,7 +452,7 @@ function App() {
     const handleResize = () => {
       const windowWidth = window.innerWidth;
       const windowHeight = window.innerHeight;
-      const videoCount = groupedAndSortedVideos.length;
+      const videoCount = orderedVideos.length;
       if (videoCount > 50) {
         const safeZoom = calculateSafeZoom(
           windowWidth,
@@ -459,25 +479,25 @@ function App() {
       window.removeEventListener("resize", debouncedResize);
       clearTimeout(resizeTimeout);
     };
-  }, [groupedAndSortedVideos.length, zoomLevel, handleZoomChange]);
+  }, [orderedVideos.length, zoomLevel, handleZoomChange]);
 
   useEffect(() => {
-    if (groupedAndSortedVideos.length > 100) {
+    if (orderedVideos.length > 100) {
       const windowWidth = window.innerWidth;
       const windowHeight = window.innerHeight;
       const safeZoom = calculateSafeZoom(
         windowWidth,
         windowHeight,
-        groupedAndSortedVideos.length
+        orderedVideos.length
       );
       if (safeZoom > zoomLevel) {
         console.log(
-          `📹 Large collection detected (${groupedAndSortedVideos.length} videos) - adjusting zoom for memory safety`
+          `📹 Large collection detected (${orderedVideos.length} videos) - adjusting zoom for memory safety`
         );
         handleZoomChange(safeZoom);
       }
     }
-  }, [groupedAndSortedVideos.length, zoomLevel, handleZoomChange]);
+  }, [orderedVideos.length, zoomLevel, handleZoomChange]);
 
   // settings load + folder selection event
   useEffect(() => {
@@ -495,6 +515,10 @@ function App() {
           setMaxConcurrentPlaying(s.maxConcurrentPlaying);
         if (s.zoomLevel !== undefined)
           setZoomLevel(clampZoomIndex(s.zoomLevel));
+        if (s.sortKey) setSortKey(s.sortKey);
+        if (s.sortDir) setSortDir(s.sortDir);
+        if (s.groupByFolders !== undefined) setGroupByFolders(s.groupByFolders);
+        if (s.randomSeed !== undefined) setRandomSeed(s.randomSeed);
       } catch {}
       setSettingsLoaded(true);
     };
@@ -517,7 +541,10 @@ function App() {
       setVideos((prev) => {
         if (prev.some((v) => v.id === videoFile.id)) return prev;
         return [...prev, videoFile].sort((a, b) =>
-          a.name.localeCompare(b.name)
+          a.basename.localeCompare(b.basename, undefined, {
+            numeric: true,
+            sensitivity: "base",
+          })
         );
       });
     };
@@ -566,8 +593,8 @@ function App() {
 
   // relayout when list changes
   useEffect(() => {
-    if (groupedAndSortedVideos.length) onItemsChanged();
-  }, [groupedAndSortedVideos.length, onItemsChanged]);
+    if (orderedVideos.length) onItemsChanged();
+  }, [orderedVideos.length, onItemsChanged]);
 
   // zoom handling via hook
   useEffect(() => {
@@ -686,6 +713,9 @@ function App() {
         file: f,
         loaded: false,
         isElectronFile: false,
+        basename: f.name,
+        dirname: "",
+        createdMs: f.lastModified || 0,
       }));
       setVideos(list);
       selection.clear();
@@ -731,6 +761,63 @@ function App() {
     },
     [recursiveMode, zoomLevel, showFilenames]
   );
+
+  const handleSortKeyChange = useCallback(
+    (key) => {
+      setSortKey(key);
+      if (key === SortKey.RANDOM && randomSeed == null) {
+        const seed = Date.now();
+        setRandomSeed(seed);
+        window.electronAPI?.saveSettingsPartial?.({
+          sortKey: key,
+          sortDir,
+          groupByFolders,
+          randomSeed: seed,
+        });
+      } else {
+        window.electronAPI?.saveSettingsPartial?.({
+          sortKey: key,
+          sortDir,
+          groupByFolders,
+          randomSeed,
+        });
+      }
+    },
+    [sortDir, groupByFolders, randomSeed]
+  );
+
+  const toggleSortDir = useCallback(() => {
+    const next = sortDir === "asc" ? "desc" : "asc";
+    setSortDir(next);
+    window.electronAPI?.saveSettingsPartial?.({
+      sortKey,
+      sortDir: next,
+      groupByFolders,
+      randomSeed,
+    });
+  }, [sortDir, sortKey, groupByFolders, randomSeed]);
+
+  const toggleGroupByFolders = useCallback(() => {
+    const next = !groupByFolders;
+    setGroupByFolders(next);
+    window.electronAPI?.saveSettingsPartial?.({
+      sortKey,
+      sortDir,
+      groupByFolders: next,
+      randomSeed,
+    });
+  }, [groupByFolders, sortKey, sortDir, randomSeed]);
+
+  const reshuffleRandom = useCallback(() => {
+    const seed = Date.now();
+    setRandomSeed(seed);
+    window.electronAPI?.saveSettingsPartial?.({
+      sortKey,
+      sortDir,
+      groupByFolders,
+      randomSeed: seed,
+    });
+  }, [sortKey, sortDir, groupByFolders]);
 
   // Selection via clicks on cards (single / ctrl-multi / shift-range / double → fullscreen)
   const handleVideoSelect = useCallback(
@@ -850,6 +937,13 @@ function App() {
             zoomLevel={zoomLevel}
             handleZoomChangeSafe={handleZoomChangeSafe}
             getMinimumZoomLevel={getMinimumZoomLevel}
+            sortKey={sortKey}
+            sortDir={sortDir}
+            groupByFolders={groupByFolders}
+            onSortKeyChange={handleSortKeyChange}
+            onSortDirToggle={toggleSortDir}
+            onGroupByFoldersToggle={toggleGroupByFolders}
+            onReshuffle={reshuffleRandom}
           />
 
           <DebugSummary
@@ -860,10 +954,11 @@ function App() {
             memoryStatus={videoCollection.memoryStatus}
             zoomLevel={zoomLevel}
             getMinimumZoomLevel={getMinimumZoomLevel}
+            sortStatus={sortStatus}
           />
 
           {/* Home state: Recent Locations when nothing is loaded */}
-          {groupedAndSortedVideos.length === 0 && !isLoadingFolder ? (
+          {orderedVideos.length === 0 && !isLoadingFolder ? (
             <>
               <RecentFolders
                 items={recentFolders}

--- a/src/components/DebugSummary.jsx
+++ b/src/components/DebugSummary.jsx
@@ -8,6 +8,7 @@ export default function DebugSummary({
   memoryStatus, // { currentMemoryMB, memoryPressure, isNearLimit, safetyMarginMB }
   zoomLevel,
   getMinimumZoomLevel,
+  sortStatus,
 }) {
   return (
     <div
@@ -23,6 +24,8 @@ export default function DebugSummary({
         gap: "0.5rem",
       }}
     >
+      {sortStatus && <span>{sortStatus}</span>}
+      {sortStatus && <span>|</span>}
       <span>🎬 {total} videos</span>
       <span>🎭 {rendered} rendered</span>
       <span>▶️ {playing} playing</span>

--- a/src/components/HeaderBar.jsx
+++ b/src/components/HeaderBar.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { ZOOM_MAX_INDEX } from "../zoom/config.js";
 import { clampZoomIndex } from "../zoom/utils.js";
+import { SortKey } from "../sorting/sorting.js";
 
 export default function HeaderBar({
   version,
@@ -16,6 +17,13 @@ export default function HeaderBar({
   zoomLevel,
   handleZoomChangeSafe,
   getMinimumZoomLevel,
+  sortKey,
+  sortDir,
+  groupByFolders,
+  onSortKeyChange,
+  onSortDirToggle,
+  onGroupByFoldersToggle,
+  onReshuffle,
 }) {
   const isElectron = !!window.electronAPI?.isElectron;
 
@@ -112,6 +120,56 @@ export default function HeaderBar({
           />
           {zoomLevel < minZoomIndex && (
             <span style={{ color: "#ffa726", fontSize: "0.7rem" }}>⚠️</span>
+          )}
+        </div>
+
+        <div
+          className="sort-control"
+          style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}
+        >
+          <span>↕️</span>
+          <select
+            value={sortKey}
+            onChange={(e) => onSortKeyChange(e.target.value)}
+            disabled={isLoadingFolder}
+          >
+            <option value={SortKey.NAME}>Name</option>
+            <option
+              value={SortKey.CREATED}
+              title="Falls back to Modified time if creation time is unavailable."
+            >
+              Created
+            </option>
+            <option value={SortKey.RANDOM}>Random</option>
+          </select>
+          {sortKey !== SortKey.RANDOM && (
+            <button
+              onClick={onSortDirToggle}
+              disabled={isLoadingFolder}
+              className="toggle-button"
+            >
+              {sortDir === "asc" ? "▲" : "▼"}
+            </button>
+          )}
+          <label
+            style={{ display: "flex", alignItems: "center", gap: "0.25rem" }}
+          >
+            <input
+              type="checkbox"
+              checked={groupByFolders}
+              onChange={onGroupByFoldersToggle}
+              disabled={isLoadingFolder}
+            />
+            Folders
+          </label>
+          {sortKey === SortKey.RANDOM && (
+            <button
+              onClick={onReshuffle}
+              disabled={isLoadingFolder}
+              className="toggle-button"
+            >
+              🔀
+            </button>
           )}
         </div>
       </div>

--- a/src/sorting/__tests__/sorting.test.js
+++ b/src/sorting/__tests__/sorting.test.js
@@ -1,0 +1,192 @@
+import { describe, it, expect } from "vitest";
+import {
+  SortKey,
+  buildComparator,
+  groupAndSort,
+  buildRandomOrderMap,
+} from "../sorting.js";
+
+const makeItem = (id, basename, dirname, createdMs) => ({
+  id,
+  basename,
+  dirname,
+  createdMs,
+});
+
+describe("sorting module", () => {
+  it("sorts by name asc/desc", () => {
+    const items = [
+      makeItem("1", "file10", "", 0),
+      makeItem("2", "file2", "", 0),
+      makeItem("3", "file1", "", 0),
+    ];
+    const asc = buildComparator({ sortKey: SortKey.NAME, sortDir: "asc" });
+    const desc = buildComparator({ sortKey: SortKey.NAME, sortDir: "desc" });
+    expect(
+      groupAndSort(items, { groupByFolders: false, comparator: asc }).map(
+        (i) => i.basename
+      )
+    ).toEqual(["file1", "file2", "file10"]);
+    expect(
+      groupAndSort(items, { groupByFolders: false, comparator: desc }).map(
+        (i) => i.basename
+      )
+    ).toEqual(["file10", "file2", "file1"]);
+  });
+
+  it("sorts by created time asc/desc", () => {
+    const items = [
+      makeItem("a", "a", "", 300),
+      makeItem("b", "b", "", 100),
+      makeItem("c", "c", "", 200),
+    ];
+    const asc = buildComparator({ sortKey: SortKey.CREATED, sortDir: "asc" });
+    const desc = buildComparator({ sortKey: SortKey.CREATED, sortDir: "desc" });
+    expect(
+      groupAndSort(items, { groupByFolders: false, comparator: asc }).map(
+        (i) => i.id
+      )
+    ).toEqual(["b", "c", "a"]);
+    expect(
+      groupAndSort(items, { groupByFolders: false, comparator: desc }).map(
+        (i) => i.id
+      )
+    ).toEqual(["a", "c", "b"]);
+  });
+
+  it("random order is stable for same seed", () => {
+    const items = [
+      makeItem("1", "1", "", 0),
+      makeItem("2", "2", "", 0),
+      makeItem("3", "3", "", 0),
+      makeItem("4", "4", "", 0),
+    ];
+    const paths = items.map((i) => i.id);
+    const seed = 42;
+    const map1 = buildRandomOrderMap(paths, seed);
+    const comp1 = buildComparator({
+      sortKey: SortKey.RANDOM,
+      sortDir: "asc",
+      randomOrderMap: map1,
+    });
+    const map2 = buildRandomOrderMap(paths, seed);
+    const comp2 = buildComparator({
+      sortKey: SortKey.RANDOM,
+      sortDir: "asc",
+      randomOrderMap: map2,
+    });
+    const order1 = groupAndSort(items, { groupByFolders: false, comparator: comp1 }).map(
+      (i) => i.id
+    );
+    const order2 = groupAndSort(items, { groupByFolders: false, comparator: comp2 }).map(
+      (i) => i.id
+    );
+    expect(order1).toEqual(order2);
+  });
+
+  it("respects sortDir when using random order", () => {
+    const items = ["1", "2", "3", "4"].map((n) => makeItem(n, n, "", 0));
+    const seed = 7;
+    const map = buildRandomOrderMap(items.map((i) => i.id), seed);
+    const asc = buildComparator({
+      sortKey: SortKey.RANDOM,
+      sortDir: "asc",
+      randomOrderMap: map,
+    });
+    const desc = buildComparator({
+      sortKey: SortKey.RANDOM,
+      sortDir: "desc",
+      randomOrderMap: map,
+    });
+    const ascOrder = groupAndSort(items, {
+      groupByFolders: false,
+      comparator: asc,
+    }).map((i) => i.id);
+    const descOrder = groupAndSort(items, {
+      groupByFolders: false,
+      comparator: desc,
+    }).map((i) => i.id);
+    expect(descOrder).toEqual([...ascOrder].reverse());
+  });
+
+  it("different seeds produce different random order", () => {
+    const items = ["1", "2", "3", "4"].map((n) => makeItem(n, n, "", 0));
+    const map1 = buildRandomOrderMap(items.map((i) => i.id), 1);
+    const map2 = buildRandomOrderMap(items.map((i) => i.id), 2);
+    const comp1 = buildComparator({
+      sortKey: SortKey.RANDOM,
+      sortDir: "asc",
+      randomOrderMap: map1,
+    });
+    const comp2 = buildComparator({
+      sortKey: SortKey.RANDOM,
+      sortDir: "asc",
+      randomOrderMap: map2,
+    });
+    const order1 = groupAndSort(items, {
+      groupByFolders: false,
+      comparator: comp1,
+    }).map((i) => i.id);
+    const order2 = groupAndSort(items, {
+      groupByFolders: false,
+      comparator: comp2,
+    }).map((i) => i.id);
+    expect(order1).not.toEqual(order2);
+  });
+
+  it("groups by folder then sorts", () => {
+    const items = [
+      makeItem("b2", "b2", "b", 0),
+      makeItem("a1", "a1", "a", 0),
+      makeItem("a2", "a2", "a", 0),
+      makeItem("b1", "b1", "b", 0),
+    ];
+    const comp = buildComparator({ sortKey: SortKey.NAME, sortDir: "asc" });
+    const result = groupAndSort(items, { groupByFolders: true, comparator: comp });
+    expect(result.map((i) => i.id)).toEqual(["a1", "a2", "b1", "b2"]);
+  });
+
+  it("places root folder group first", () => {
+    const items = [
+      makeItem("root2", "b", "", 0),
+      makeItem("a1", "a1", "a", 0),
+      makeItem("root1", "a", "", 0),
+      makeItem("b1", "b1", "b", 0),
+    ];
+    const comp = buildComparator({ sortKey: SortKey.NAME, sortDir: "asc" });
+    const result = groupAndSort(items, { groupByFolders: true, comparator: comp });
+    expect(result.map((i) => i.id)).toEqual(["root1", "root2", "a1", "b1"]);
+  });
+
+  it("handles missing created timestamps", () => {
+    const items = [
+      makeItem("1", "a", "", undefined),
+      makeItem("2", "b", "", 100),
+    ];
+    const comp = buildComparator({ sortKey: SortKey.CREATED, sortDir: "asc" });
+    const result = groupAndSort(items, { groupByFolders: false, comparator: comp });
+    expect(result.map((i) => i.id)).toEqual(["1", "2"]);
+  });
+
+  it("orderedVideos updates when state changes", () => {
+    const items = [
+      makeItem("1", "a", "a", 100),
+      makeItem("2", "c", "b", 150),
+      makeItem("3", "b", "b", 50),
+    ];
+    const compName = buildComparator({ sortKey: SortKey.NAME, sortDir: "asc" });
+    const withGrouping = groupAndSort(items, {
+      groupByFolders: true,
+      comparator: compName,
+    });
+    const compCreated = buildComparator({
+      sortKey: SortKey.CREATED,
+      sortDir: "desc",
+    });
+    const withoutGrouping = groupAndSort(items, {
+      groupByFolders: false,
+      comparator: compCreated,
+    });
+    expect(withGrouping).not.toEqual(withoutGrouping);
+  });
+});

--- a/src/sorting/sorting.js
+++ b/src/sorting/sorting.js
@@ -1,0 +1,73 @@
+export const SortKey = {
+  NAME: "name",
+  CREATED: "created",
+  RANDOM: "random",
+};
+
+export function mulberry32(a) {
+  return function () {
+    let t = (a += 0x6d2b79f5);
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+export function hashString(str) {
+  let h = 0;
+  for (let i = 0; i < str.length; i++) {
+    h = (h << 5) - h + str.charCodeAt(i);
+    h |= 0;
+  }
+  return h >>> 0;
+}
+
+export function buildRandomOrderMap(paths, seed) {
+  const prng = mulberry32(seed >>> 0);
+  const map = {};
+  paths.forEach((p) => {
+    map[p] = prng();
+  });
+  return map;
+}
+
+export function buildComparator({ sortKey, sortDir, randomOrderMap }) {
+  const dir = sortDir === "desc" ? -1 : 1;
+  if (sortKey === SortKey.CREATED) {
+    return (a, b) => ((a.createdMs || 0) - (b.createdMs || 0)) * dir;
+  }
+  if (sortKey === SortKey.RANDOM) {
+    return (a, b) => {
+      const ra = randomOrderMap?.[a.id] ?? 0;
+      const rb = randomOrderMap?.[b.id] ?? 0;
+      return (ra - rb) * dir;
+    };
+  }
+  // default NAME
+  return (a, b) =>
+    a.basename.localeCompare(b.basename, undefined, {
+      numeric: true,
+      sensitivity: "base",
+    }) * dir;
+}
+
+export function groupAndSort(items, { groupByFolders, comparator }) {
+  if (!groupByFolders) {
+    return [...items].sort(comparator);
+  }
+  const groups = new Map();
+  items.forEach((item) => {
+    const key = item.dirname || "";
+    if (!groups.has(key)) groups.set(key, []);
+    groups.get(key).push(item);
+  });
+  const sortedGroupKeys = Array.from(groups.keys()).sort((a, b) =>
+    a.localeCompare(b, undefined, { numeric: true, sensitivity: "base" })
+  );
+  const result = [];
+  sortedGroupKeys.forEach((key) => {
+    const groupItems = groups.get(key).sort(comparator);
+    result.push(...groupItems);
+  });
+  return result;
+}


### PR DESCRIPTION
## Summary
- expose basename, dirname and createdMs metadata in main process
- add sorting utilities with name/created/random modes and folder grouping
- wire up persistent sort settings with UI controls and status display
- expand unit tests for sorting and grouping, covering random direction, seed variance, root grouping and missing timestamps

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bd6974108c832c83bbae8976336e68