### PR TITLE
feat: shrink video limits on player creation failures

### DIFF
--- a/src/components/VideoCard/VideoCard.jsx
+++ b/src/components/VideoCard/VideoCard.jsx
@@ -25,6 +25,7 @@ const VideoCard = memo(function VideoCard({
   onVideoPlay,            // (id)
   onVideoPause,           // (id)
   onPlayError,            // (id, error)
+  reportPlayerCreationFailure,
   onVisibilityChange,     // (id, visible)
   onHover,                // (id)
 
@@ -316,6 +317,7 @@ const VideoCard = memo(function VideoCard({
 
         if (terminal && decodeWhileActive && !looksTransientLocal) {
           permanentErrorRef.current = true;
+          reportPlayerCreationFailure?.();
         }
 
         setErrorText(`⚠️ ${looksTransientLocal ? "Temporary read error" : label}`);

--- a/src/hooks/video-collection/useVideoCollection.js
+++ b/src/hooks/video-collection/useVideoCollection.js
@@ -66,7 +66,12 @@ export default function useVideoCollection({
   );
 
   // Layer 2: Resource management (Browser performance)
-  const { canLoadVideo, performCleanup, limits } = useVideoResourceManager({
+  const {
+    canLoadVideo,
+    performCleanup,
+    limits,
+    reportPlayerCreationFailure,
+  } = useVideoResourceManager({
     progressiveVideos,
     visibleVideos,
     loadedVideos,
@@ -95,6 +100,7 @@ export default function useVideoCollection({
     markHover,
     reportPlayError,
     reportStarted,
+    reportPlayerCreationFailure,
 
     // Functions for parent
     performCleanup,


### PR DESCRIPTION
## Summary
- allow `VideoCard` to report terminal player creation failures
- halve loading limits in `useVideoResourceManager` and trigger cleanup
- expose failure callback through `useVideoCollection`
- test limit reduction and updated `canLoadVideo`

## Testing
- `npx vitest run`