### PR TITLE
Bound rendered tiles and add video teardown

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -976,6 +976,7 @@ function App() {
                   canLoadMoreVideos={() =>
                     videoCollection.canLoadVideo(video.id)
                   }
+                  evictionVictims={videoCollection.evictionVictims}
                   isLoading={loadingVideos.has(video.id)}
                   isLoaded={loadedVideos.has(video.id)}
                   isVisible={visibleVideos.has(video.id)}

--- a/src/components/VideoCard/VideoCard.jsx
+++ b/src/components/VideoCard/VideoCard.jsx
@@ -3,6 +3,7 @@ import React, { useState, useEffect, useRef, useCallback, memo } from "react";
 import { classifyMediaError } from "./mediaError";
 import { toFileURL, hardDetach } from "./videoDom";
 import { useVideoStallWatchdog } from "../../hooks/useVideoStallWatchdog";
+import { hardTeardownVideo } from "../../utils/media";
 
 const VideoCard = memo(function VideoCard({
   video,
@@ -28,6 +29,7 @@ const VideoCard = memo(function VideoCard({
   reportPlayerCreationFailure,
   onVisibilityChange,     // (id, visible)
   onHover,                // (id)
+  evictionVictims = [],
 
   // IO registry
   observeIntersection,    // (el, id, cb)
@@ -39,7 +41,9 @@ const VideoCard = memo(function VideoCard({
   const cardRef = useRef(null);
   const videoContainerRef = useRef(null);
   const videoRef = useRef(null);
-
+  const objectUrlRef = useRef(null);
+  const persistentListenersRef = useRef([]);
+  
   const clickTimeoutRef = useRef(null);
   const loadTimeoutRef = useRef(null);
 
@@ -53,6 +57,7 @@ const VideoCard = memo(function VideoCard({
   const permanentErrorRef = useRef(false);
   const retryAttemptsRef   = useRef(0);
   const suppressErrorsRef  = useRef(false); // ignore unload-induced errors
+  const lastCanLoadRef     = useRef(true);
 
   const [errorText, setErrorText] = useState(null);
   const videoId = video.id || video.fullPath || video.name;
@@ -62,6 +67,36 @@ const VideoCard = memo(function VideoCard({
     const el = videoRef.current;
     return !!(el && el.dataset && el.dataset.adopted === "modal");
   }, []);
+
+  const runHardTeardown = useCallback(() => {
+    const el = videoRef.current;
+    if (!el || isAdoptedByModal()) return;
+
+    if (loadTimeoutRef.current) {
+      clearTimeout(loadTimeoutRef.current);
+      loadTimeoutRef.current = null;
+    }
+
+    try {
+      suppressErrorsRef.current = true;
+      hardTeardownVideo(el, {
+        objectURL: objectUrlRef.current,
+        listeners: persistentListenersRef.current,
+      });
+    } finally {
+      setTimeout(() => {
+        suppressErrorsRef.current = false;
+      }, 0);
+    }
+
+    videoRef.current = null;
+    objectUrlRef.current = null;
+    persistentListenersRef.current = [];
+    loadRequestedRef.current = false;
+    metaNotifiedRef.current = false;
+    setLoaded(false);
+    setLoading(false);
+  }, [isAdoptedByModal]);
 
   // mirror flags
   useEffect(() => setLoaded(isLoaded), [isLoaded]);
@@ -79,28 +114,28 @@ const VideoCard = memo(function VideoCard({
     }
   }, [video.id, video.size, video.dateModified]);
 
+  useEffect(() => {
+    const allowed = canLoadMoreVideos?.() ?? true;
+    const prev = lastCanLoadRef.current;
+    lastCanLoadRef.current = allowed;
+    if (!allowed && prev) {
+      runHardTeardown();
+    }
+  }, [canLoadMoreVideos, runHardTeardown]);
+
   // Teardown when parent says not loaded/not loading (unless adopted by modal)
   useEffect(() => {
-    if (isAdoptedByModal()) return;
-    if (!isLoaded && !isLoading && videoRef.current) {
-      const el = videoRef.current;
-      try {
-        suppressErrorsRef.current = true;
-        if (el.src?.startsWith("blob:")) URL.revokeObjectURL(el.src);
-        el.pause();
-        el.removeAttribute("src");
-        el.remove();
-      } catch {}
-      finally {
-        setTimeout(() => { suppressErrorsRef.current = false; }, 0);
-      }
-      videoRef.current = null;
-      loadRequestedRef.current = false;
-      metaNotifiedRef.current = false;
-      setLoaded(false);
-      setLoading(false);
+    if (!isLoaded && !isLoading && videoRef.current && !isAdoptedByModal()) {
+      runHardTeardown();
     }
-  }, [isLoaded, isLoading, isAdoptedByModal]);
+  }, [isLoaded, isLoading, isAdoptedByModal, runHardTeardown]);
+
+  useEffect(() => {
+    if (!videoRef.current) return;
+    if (!Array.isArray(evictionVictims) || evictionVictims.length === 0) return;
+    if (!evictionVictims.includes(videoId)) return;
+    runHardTeardown();
+  }, [evictionVictims, videoId, runHardTeardown]);
 
   // IO registration for visibility
   useEffect(() => {
@@ -192,9 +227,15 @@ const VideoCard = memo(function VideoCard({
       hardDetach(el);
     };
 
-    el.addEventListener("playing", handlePlaying);
-    el.addEventListener("pause",   handlePause);
-    el.addEventListener("error",   handleError);
+    const listeners = [
+      ["playing", handlePlaying],
+      ["pause", handlePause],
+      ["error", handleError],
+    ];
+    for (const [type, handler] of listeners) {
+      el.addEventListener(type, handler);
+    }
+    persistentListenersRef.current = listeners;
 
     if (isPlaying && isVisible && loaded && !permanentErrorRef.current) {
       const p = el.play();
@@ -204,11 +245,22 @@ const VideoCard = memo(function VideoCard({
     }
 
     return () => {
-      el.removeEventListener("playing", handlePlaying);
-      el.removeEventListener("pause",   handlePause);
-      el.removeEventListener("error",   handleError);
+      for (const [type, handler] of listeners) {
+        el.removeEventListener(type, handler);
+      }
+      if (persistentListenersRef.current === listeners) {
+        persistentListenersRef.current = [];
+      }
     };
-  }, [isPlaying, isVisible, loaded, videoId, onVideoPlay, onVideoPause, onPlayError]);
+  }, [
+    isPlaying,
+    isVisible,
+    loaded,
+    videoId,
+    onVideoPlay,
+    onVideoPause,
+    onPlayError,
+  ]);
 
   // Quiet stall watchdog (no visual changes)
   useEffect(() => {
@@ -367,11 +419,22 @@ const VideoCard = memo(function VideoCard({
       el.addEventListener("error",         onErr);
 
       try {
+        const assignObjectURL = (next) => {
+          if (objectUrlRef.current && objectUrlRef.current !== next) {
+            try { URL.revokeObjectURL(objectUrlRef.current); } catch {}
+          }
+          objectUrlRef.current = next;
+        };
+
         if (video.isElectronFile && video.fullPath) {
+          assignObjectURL(null);
           el.src = toFileURL(video.fullPath);
         } else if (video.file) {
-          el.src = URL.createObjectURL(video.file);
+          const url = URL.createObjectURL(video.file);
+          assignObjectURL(url);
+          el.src = url;
         } else if (video.fullPath || video.relativePath) {
+          assignObjectURL(null);
           el.src = video.fullPath || video.relativePath;
         } else {
           throw new Error("No valid video source");
@@ -416,24 +479,9 @@ const VideoCard = memo(function VideoCard({
     return () => {
       if (loadTimeoutRef.current) clearTimeout(loadTimeoutRef.current);
       if (clickTimeoutRef.current) clearTimeout(clickTimeoutRef.current);
-      const el = videoRef.current;
-      if (el && !(el.dataset?.adopted === "modal")) {
-        try {
-          suppressErrorsRef.current = true;
-          if (el.src?.startsWith("blob:")) URL.revokeObjectURL(el.src);
-          el.pause();
-          el.removeAttribute("src");
-          el.remove();
-        } catch {}
-        finally {
-          setTimeout(() => { suppressErrorsRef.current = false; }, 0);
-        }
-      }
-      videoRef.current = null;
-      loadRequestedRef.current = false;
-      metaNotifiedRef.current = false;
+      runHardTeardown();
     };
-  }, []);
+  }, [runHardTeardown]);
 
   // UI handlers (unchanged)
   const handleClick = useCallback((e) => {

--- a/src/components/VideoCard/__tests__/ui.test.jsx
+++ b/src/components/VideoCard/__tests__/ui.test.jsx
@@ -2,6 +2,7 @@
 import React from "react";
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { render, screen, act } from "@testing-library/react";
+import * as mediaModule from "../../../utils/media";
 import VideoCard from "../VideoCard";
 
 // Keep a handle to the native createElement so our mocks can delegate safely
@@ -24,6 +25,7 @@ beforeEach(() => {
 });
 
 let lastVideoEl;
+let hardTeardownSpy;
 
 // --- Base createElement mock: augment a REAL <video> Node so DOM APIs work ---
 beforeEach(() => {
@@ -54,10 +56,15 @@ beforeEach(() => {
     lastVideoEl = el; // capture for assertions in other tests
     return el;
   });
+
+  hardTeardownSpy = vi
+    .spyOn(mediaModule, "hardTeardownVideo")
+    .mockImplementation(() => {});
 });
 
 afterEach(() => {
   vi.restoreAllMocks();
+  hardTeardownSpy = undefined;
 });
 
 // --- Common props scaffold ---
@@ -80,6 +87,7 @@ const baseProps = {
   onVisibilityChange: vi.fn(),
   onHover: vi.fn(),
   ioRoot: { current: null },
+  evictionVictims: [],
 };
 
 describe("VideoCard", () => {
@@ -226,5 +234,67 @@ describe("VideoCard", () => {
       // @ts-ignore
       global.IntersectionObserver = PrevIO;
     }
+  });
+
+  it("tears down aggressively when evicted", async () => {
+    const video = {
+      id: "victim",
+      name: "victim",
+      isElectronFile: true,
+      fullPath: "C:/videos/victim.mp4",
+    };
+
+    const { rerender } = render(
+      <VideoCard
+        {...baseProps}
+        video={video}
+        isVisible
+        isLoaded={false}
+        isLoading={false}
+        scheduleInit={(fn) => fn()}
+        evictionVictims={[]}
+      />
+    );
+
+    await act(async () => {});
+    await act(async () => {
+      lastVideoEl?.dispatchEvent?.(new Event("loadeddata"));
+    });
+
+    expect(hardTeardownSpy).not.toHaveBeenCalled();
+
+    rerender(
+      <VideoCard
+        {...baseProps}
+        video={video}
+        isVisible
+        isLoaded
+        isLoading={false}
+        scheduleInit={(fn) => fn()}
+        evictionVictims={[]}
+      />
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(hardTeardownSpy).not.toHaveBeenCalled();
+
+    rerender(
+      <VideoCard
+        {...baseProps}
+        video={video}
+        isVisible
+        isLoaded
+        isLoading={false}
+        scheduleInit={(fn) => fn()}
+        evictionVictims={[video.id]}
+      />
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(hardTeardownSpy).toHaveBeenCalled();
   });
 });

--- a/src/hooks/video-collection/useProgressiveList.js
+++ b/src/hooks/video-collection/useProgressiveList.js
@@ -43,34 +43,55 @@ export function useProgressiveList(
 
     // Force interval mode (useful for tests/SSR)
     forceInterval = false,
+
+    // Cap the number of rendered (mounted) items regardless of total length
+    maxRendered = Infinity,
   } = options;
 
   const safe = Array.isArray(items) ? items : [];
-  const [visible, setVisible] = useState(() => Math.min(initial, safe.length));
+  const normalizedMaxRendered = Number.isFinite(maxRendered)
+    ? Math.max(0, Math.floor(maxRendered))
+    : Number.POSITIVE_INFINITY;
+  const targetCount = Math.min(safe.length, normalizedMaxRendered);
+  const [visible, setVisible] = useState(() =>
+    Math.min(initial, targetCount)
+  );
   const prevLenRef = useRef(safe.length);
+  const prevTargetRef = useRef(targetCount);
   const didInitRef = useRef(false);
 
   // ---- Clamp logic: initialize once; clamp on shrink; don't reset on growth ----
   useEffect(() => {
     const len = safe.length;
-    if (!didInitRef.current) {
-      didInitRef.current = true;
-      setVisible((v) => Math.min(v, len));
-      prevLenRef.current = len;
-      return;
-    }
+    const normalized = Number.isFinite(maxRendered)
+      ? Math.max(0, Math.floor(maxRendered))
+      : Number.POSITIVE_INFINITY;
+    const nextTarget = Math.min(len, normalized);
 
-    // If list shrank below currently visible, clamp down.
-    if (len < prevLenRef.current && visible > len) {
-      setVisible(len);
-    }
-    // Do not reset visible on growth.
-    prevLenRef.current = len;
+    setVisible((current) => {
+      let next = current;
+
+      if (!didInitRef.current) {
+        didInitRef.current = true;
+        next = Math.min(current, nextTarget);
+      } else {
+        if (len < prevLenRef.current && next > len) {
+          next = Math.min(next, len);
+        }
+        if (nextTarget < prevTargetRef.current && next > nextTarget) {
+          next = Math.min(next, nextTarget);
+        }
+      }
+
+      prevLenRef.current = len;
+      prevTargetRef.current = nextTarget;
+      return next;
+    });
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [safe.length]);
+  }, [safe.length, maxRendered]);
 
   // Short-circuit when fully visible
-  const allVisible = visible >= safe.length;
+  const allVisible = visible >= targetCount;
 
   // ---------------------- Scheduling strategies ----------------------
 
@@ -194,7 +215,9 @@ export function useProgressiveList(
         if (cancelled) return;
         if (!allVisible) {
           const add = computeNextBatch();
-          setVisible((v) => (v < safe.length ? Math.min(v + add, safe.length) : v));
+          setVisible((v) =>
+            v < targetCount ? Math.min(v + add, targetCount) : v
+          );
         }
         // Chain next idle tick
         rafId = requestAnimationFrame(schedule);
@@ -234,12 +257,18 @@ export function useProgressiveList(
 
     const timer = setInterval(() => {
       setVisible((v) =>
-        v < safe.length ? Math.min(v + batchSize, safe.length) : v
+        v < targetCount ? Math.min(v + batchSize, targetCount) : v
       );
     }, intervalMs);
 
     return () => clearInterval(timer);
-  }, [shouldUseInterval, allVisible, safe.length, batchSize, intervalMs]);
+  }, [
+    shouldUseInterval,
+    allVisible,
+    targetCount,
+    batchSize,
+    intervalMs,
+  ]);
 
   return safe.slice(0, visible);
 }

--- a/src/hooks/video-collection/useProgressiveList.test.js
+++ b/src/hooks/video-collection/useProgressiveList.test.js
@@ -32,6 +32,49 @@ describe("useProgressiveList", () => {
     expect(result.current.length).toBe(100);
   });
 
+  it("honors maxRendered cap and clamps when the cap shrinks", () => {
+    vi.useFakeTimers();
+    const items = Array.from({ length: 200 }, (_, i) => i);
+
+    const { result, rerender } = renderHook(
+      ({ cap }) =>
+        useProgressiveList(items, 50, 25, 1, {
+          forceInterval: true,
+          pauseOnScroll: false,
+          longTaskAdaptation: false,
+          maxRendered: cap,
+        }),
+      { initialProps: { cap: 80 } }
+    );
+
+    expect(result.current.length).toBe(50);
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(result.current.length).toBe(75);
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(result.current.length).toBe(80);
+
+    act(() => {
+      vi.advanceTimersByTime(5);
+    });
+    expect(result.current.length).toBe(80);
+
+    rerender({ cap: 60 });
+    expect(result.current.length).toBe(60);
+
+    act(() => {
+      vi.advanceTimersByTime(5);
+    });
+    expect(result.current.length).toBe(60);
+
+    vi.useRealTimers();
+  });
+
   test("clamps down on shrink, does not reset on growth", () => {
     vi.useFakeTimers();
     let items = Array.from({ length: 120 }, (_, i) => i);

--- a/src/hooks/video-collection/useVideoCollection.js
+++ b/src/hooks/video-collection/useVideoCollection.js
@@ -1,7 +1,10 @@
 // hooks/video-collection/useVideoCollection.js
+import { useEffect, useState } from "react";
 import { useProgressiveList } from "./useProgressiveList";
 import useVideoResourceManager from "./useVideoResourceManager";
 import usePlayOrchestrator from "./usePlayOrchestrator";
+
+const MAX_TILES_BUFFER = 48;
 
 export const PROGRESSIVE_DEFAULTS = {
   initial: 100,
@@ -50,6 +53,9 @@ export default function useVideoCollection({
     Number.isFinite(intervalMs) ? intervalMs : PROGRESSIVE_DEFAULTS.intervalMs
   );
 
+  const [renderCap, setRenderCap] = useState(Number.POSITIVE_INFINITY);
+  const [evictionVictims, setEvictionVictims] = useState([]);
+
   // Layer 1: Progressive rendering (React performance)
   const progressiveVideos = useProgressiveList(
     videos,
@@ -62,6 +68,7 @@ export default function useVideoCollection({
       longTaskAdaptation,
       hadLongTaskRecently,
       forceInterval: !!forceInterval,
+      maxRendered: renderCap,
     }
   );
 
@@ -70,6 +77,7 @@ export default function useVideoCollection({
     canLoadVideo,
     performCleanup,
     limits,
+    memoryStatus,
     reportPlayerCreationFailure,
   } = useVideoResourceManager({
     progressiveVideos,
@@ -90,12 +98,61 @@ export default function useVideoCollection({
       maxPlaying: maxConcurrentPlaying,
     });
 
+  const collectionSize = (collection) => {
+    if (!collection) return 0;
+    if (typeof collection.size === "number") return collection.size;
+    if (Array.isArray(collection)) return collection.length;
+    try {
+      return Array.from(collection).length;
+    } catch {
+      return 0;
+    }
+  };
+
+  const loadedCount = collectionSize(loadedVideos);
+  const visibleCount = collectionSize(visibleVideos);
+
+  useEffect(() => {
+    const safeMaxLoaded = Number.isFinite(limits?.maxLoaded)
+      ? Math.max(0, limits.maxLoaded)
+      : videos.length;
+    const safeMaxLoading = Number.isFinite(limits?.maxConcurrentLoading)
+      ? Math.max(0, limits.maxConcurrentLoading)
+      : 0;
+
+    const rawCap = safeMaxLoaded + safeMaxLoading + MAX_TILES_BUFFER;
+    const boundedCap = Math.min(videos.length, Math.max(0, Math.floor(rawCap)));
+
+    setRenderCap((prev) => (prev === boundedCap ? prev : boundedCap));
+  }, [videos.length, limits?.maxLoaded, limits?.maxConcurrentLoading]);
+
+  useEffect(() => {
+    if (typeof performCleanup !== "function") {
+      setEvictionVictims((prev) => (prev.length ? [] : prev));
+      return;
+    }
+    const victims = performCleanup() || [];
+    setEvictionVictims((prev) => {
+      if (prev.length === victims.length && prev.every((id, idx) => id === victims[idx])) {
+        return prev;
+      }
+      return victims;
+    });
+  }, [
+    performCleanup,
+    loadedCount,
+    visibleCount,
+    limits?.maxLoaded,
+    limits?.maxConcurrentLoading,
+  ]);
+
   return {
     // What to render
     videosToRender: progressiveVideos,
 
     // Functions for VideoCard
     canLoadVideo,
+    evictionVictims,
     isVideoPlaying: (videoId) => playingSet.has(videoId),
     markHover,
     reportPlayError,
@@ -104,6 +161,7 @@ export default function useVideoCollection({
 
     // Functions for parent
     performCleanup,
+    limits,
 
     // Derived state for UI
     playingVideos: playingSet,
@@ -113,6 +171,8 @@ export default function useVideoCollection({
       playing: playingSet.size,
       loaded: loadedVideos.size,
     },
+
+    memoryStatus,
 
     // Debug info (development only)
     debug:

--- a/src/hooks/video-collection/useVideoCollection.test.js
+++ b/src/hooks/video-collection/useVideoCollection.test.js
@@ -1,14 +1,81 @@
 // src/hooks/video-collection/useVideoCollection.test.js
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { renderHook, act } from "@testing-library/react";
+
+const mocks = vi.hoisted(() => {
+  const performCleanup = vi.fn(() => []);
+  const canLoadVideo = vi.fn(() => true);
+  const limits = { maxLoaded: 999, maxConcurrentLoading: 64 };
+  const memoryStatus = {
+    currentMemoryMB: 512,
+    memoryPressure: 25,
+    isNearLimit: false,
+    safetyMarginMB: 512,
+  };
+  const reportPlayerCreationFailure = vi.fn();
+  const playingSet = new Set();
+  const markHover = vi.fn();
+  const reportPlayError = vi.fn();
+  const reportStarted = vi.fn();
+
+  return {
+    performCleanup,
+    canLoadVideo,
+    limits,
+    memoryStatus,
+    reportPlayerCreationFailure,
+    playingSet,
+    markHover,
+    reportPlayError,
+    reportStarted,
+  };
+});
+
+vi.mock("./useVideoResourceManager", () => ({
+  __esModule: true,
+  default: vi.fn(() => ({
+    canLoadVideo: mocks.canLoadVideo,
+    performCleanup: mocks.performCleanup,
+    limits: mocks.limits,
+    memoryStatus: mocks.memoryStatus,
+    reportPlayerCreationFailure: mocks.reportPlayerCreationFailure,
+  })),
+}));
+
+vi.mock("./usePlayOrchestrator", () => ({
+  __esModule: true,
+  default: vi.fn(() => ({
+    playingSet: mocks.playingSet,
+    markHover: mocks.markHover,
+    reportPlayError: mocks.reportPlayError,
+    reportStarted: mocks.reportStarted,
+  })),
+}));
+
 import useVideoCollection, { PROGRESSIVE_DEFAULTS } from "./useVideoCollection";
 
 const makeVideos = (n) =>
   Array.from({ length: n }, (_, i) => ({ id: `v${i}`, name: `v${i}` }));
 
 describe("useVideoCollection (composite)", () => {
-  beforeEach(() => vi.useFakeTimers());
-  afterEach(() => vi.useRealTimers());
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mocks.performCleanup.mockReset();
+    mocks.canLoadVideo.mockReset();
+    mocks.reportPlayerCreationFailure.mockReset();
+    mocks.markHover.mockReset();
+    mocks.reportPlayError.mockReset();
+    mocks.reportStarted.mockReset();
+    mocks.playingSet.clear();
+    mocks.limits.maxLoaded = 999;
+    mocks.limits.maxConcurrentLoading = 64;
+    mocks.performCleanup.mockReturnValue([]);
+    mocks.canLoadVideo.mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
 
   it("progressive render count + playing state + stats (explicit config)", () => {
     const videos = makeVideos(120);
@@ -50,14 +117,50 @@ describe("useVideoCollection (composite)", () => {
   it("uses defaults when progressive not provided", () => {
     const videos = makeVideos(120);
 
-    const { result } = renderHook(() =>
-      useVideoCollection({ videos })
+    const { result } = renderHook(() => useVideoCollection({ videos }));
+
+    expect(result.current.videosToRender.length).toBe(
+      PROGRESSIVE_DEFAULTS.initial
+    );
+    expect(result.current.stats.total).toBe(120);
+    expect(result.current.stats.rendered).toBe(
+      PROGRESSIVE_DEFAULTS.initial
+    );
+  });
+
+  it("exposes eviction victims from performCleanup", async () => {
+    const videos = makeVideos(10);
+    const victimsQueue = [["v3", "v4"], []];
+    mocks.performCleanup.mockImplementation(() => victimsQueue.shift() || []);
+
+    const { result, rerender } = renderHook(
+      ({ loadedIds, visibleIds }) =>
+        useVideoCollection({
+          videos,
+          loadedVideos: new Set(loadedIds),
+          visibleVideos: new Set(visibleIds),
+          progressive: {
+            initial: 10,
+            batchSize: 10,
+            intervalMs: 1,
+            forceInterval: true,
+            pauseOnScroll: false,
+            longTaskAdaptation: false,
+          },
+        }),
+      {
+        initialProps: {
+          loadedIds: ["v1", "v2", "v3", "v4"],
+          visibleIds: ["v1"],
+        },
+      }
     );
 
-    expect(result.current.videosToRender.length)
-      .toBe(PROGRESSIVE_DEFAULTS.initial);
-    expect(result.current.stats.total).toBe(120);
-    expect(result.current.stats.rendered)
-      .toBe(PROGRESSIVE_DEFAULTS.initial);
+    await act(async () => {});
+    expect(result.current.evictionVictims).toEqual(["v3", "v4"]);
+
+    rerender({ loadedIds: ["v1", "v2"], visibleIds: ["v1"] });
+    await act(async () => {});
+    expect(result.current.evictionVictims).toEqual([]);
   });
 });

--- a/src/utils/media.js
+++ b/src/utils/media.js
@@ -1,0 +1,48 @@
+// src/utils/media.js
+// Utilities for aggressively releasing media resources
+
+/**
+ * Fully detach a <video> element from its sources and listeners.
+ * Ensures Chromium frees decoders, file handles, and GPU resources.
+ */
+export function hardTeardownVideo(video, opts = {}) {
+  if (!video) return;
+
+  const {
+    objectURL = null,
+    listeners = [],
+    mediaSource = null,
+  } = opts;
+
+  try { video.pause(); } catch {}
+
+  if (Array.isArray(listeners)) {
+    for (const [type, handler] of listeners) {
+      if (!type || !handler) continue;
+      try { video.removeEventListener(type, handler); } catch {}
+    }
+  }
+
+  try { video.removeAttribute("src"); } catch {}
+  try { video.srcObject = null; } catch {}
+  try { video.src = ""; } catch {}
+
+  const currentSrc = (() => {
+    try { return typeof video.currentSrc === "string" && video.currentSrc ? video.currentSrc : video.src; }
+    catch { return ""; }
+  })();
+
+  if (objectURL) {
+    try { URL.revokeObjectURL(objectURL); } catch {}
+  } else if (currentSrc && currentSrc.startsWith("blob:")) {
+    try { URL.revokeObjectURL(currentSrc); } catch {}
+  }
+
+  if (mediaSource && typeof mediaSource.endOfStream === "function") {
+    try { mediaSource.endOfStream(); } catch {}
+  }
+
+  try { video.load(); } catch {}
+
+  try { video.remove(); } catch {}
+}


### PR DESCRIPTION
## Summary
- add a maxRendered guard to useProgressiveList and pipe resource caps through useVideoCollection
- introduce a hardTeardownVideo helper and ensure VideoCard tears down when evicted or disallowed
- extend unit tests for the collection hook and VideoCard eviction behavior

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68d11d5fb8c0832cad5d1028dbf139cf