### PR TITLE
Optimize visible video updates

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -613,6 +613,11 @@ function App() {
 
   const handleVideoVisibilityChange = useCallback((videoId, isVisible) => {
     setVisibleVideos((prev) => {
+      const currentlyVisible = prev.has(videoId);
+      if (currentlyVisible === isVisible) {
+        return prev;
+      }
+
       const ns = new Set(prev);
       if (isVisible) ns.add(videoId);
       else ns.delete(videoId);


### PR DESCRIPTION
## Summary
- skip cloning the visible video Set when the visibility state does not change
- only clone and update the Set when the membership actually needs to change

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68d1385b5714832cadaea1743bac7ce2