### PR TITLE
Ensure pending VideoCard loads notify stop during teardown

### DIFF
--- a/src/components/VideoCard/VideoCard.jsx
+++ b/src/components/VideoCard/VideoCard.jsx
@@ -50,6 +50,9 @@ const VideoCard = memo(function VideoCard({
   // local mirrors (parent is source of truth)
   const [loaded, setLoaded] = useState(false);
   const [loading, setLoading] = useState(false);
+  const loadingStateRef = useRef(loading);
+  const isLoadingPropRef = useRef(isLoading);
+  const onStopLoadingRef = useRef(onStopLoading);
 
   // guards
   const loadRequestedRef = useRef(false);
@@ -69,24 +72,37 @@ const VideoCard = memo(function VideoCard({
   }, []);
 
   const runHardTeardown = useCallback(() => {
+    if (isAdoptedByModal()) return;
+
     const el = videoRef.current;
-    if (!el || isAdoptedByModal()) return;
+    const hadPendingLoad =
+      loadRequestedRef.current ||
+      loadingStateRef.current ||
+      isLoadingPropRef.current;
+
+    if (hadPendingLoad) {
+      onStopLoadingRef.current?.(videoId);
+    }
 
     if (loadTimeoutRef.current) {
       clearTimeout(loadTimeoutRef.current);
       loadTimeoutRef.current = null;
     }
 
-    try {
-      suppressErrorsRef.current = true;
-      hardTeardownVideo(el, {
-        objectURL: objectUrlRef.current,
-        listeners: persistentListenersRef.current,
-      });
-    } finally {
-      setTimeout(() => {
-        suppressErrorsRef.current = false;
-      }, 0);
+    if (el) {
+      try {
+        suppressErrorsRef.current = true;
+        hardTeardownVideo(el, {
+          objectURL: objectUrlRef.current,
+          listeners: persistentListenersRef.current,
+        });
+      } finally {
+        setTimeout(() => {
+          suppressErrorsRef.current = false;
+        }, 0);
+      }
+    } else if (objectUrlRef.current) {
+      try { URL.revokeObjectURL(objectUrlRef.current); } catch {}
     }
 
     videoRef.current = null;
@@ -94,13 +110,27 @@ const VideoCard = memo(function VideoCard({
     persistentListenersRef.current = [];
     loadRequestedRef.current = false;
     metaNotifiedRef.current = false;
+    loadingStateRef.current = false;
+    isLoadingPropRef.current = false;
     setLoaded(false);
     setLoading(false);
-  }, [isAdoptedByModal]);
+  }, [
+    isAdoptedByModal,
+    videoId,
+  ]);
 
   // mirror flags
   useEffect(() => setLoaded(isLoaded), [isLoaded]);
   useEffect(() => setLoading(isLoading), [isLoading]);
+  useEffect(() => {
+    loadingStateRef.current = loading;
+  }, [loading]);
+  useEffect(() => {
+    isLoadingPropRef.current = isLoading;
+  }, [isLoading]);
+  useEffect(() => {
+    onStopLoadingRef.current = onStopLoading;
+  }, [onStopLoading]);
 
   // If file content changed, clear sticky error so we can retry
   useEffect(() => {
@@ -289,6 +319,7 @@ const VideoCard = memo(function VideoCard({
 
     loadRequestedRef.current = true;
     onStartLoading?.(videoId);
+    loadingStateRef.current = true;
     setLoading(true);
 
     const runInit = () => {
@@ -312,6 +343,8 @@ const VideoCard = memo(function VideoCard({
 
       const finishStopLoading = () => {
         onStopLoading?.(videoId);
+        loadingStateRef.current = false;
+        isLoadingPropRef.current = false;
         setLoading(false);
       };
 

--- a/src/components/VideoCard/__tests__/ui.test.jsx
+++ b/src/components/VideoCard/__tests__/ui.test.jsx
@@ -97,8 +97,8 @@ describe("VideoCard", () => {
       const el = NATIVE_CREATE_ELEMENT(tag, opts);
       if (tag === "video") {
         // Ensure media stubs exist
-        if (!el.pause) el.pause = vi.fn();
-        if (!el.play) el.play = vi.fn().mockResolvedValue(undefined);
+        el.pause = vi.fn();
+        el.play = vi.fn().mockResolvedValue(undefined);
         // Force the initial load() inside runInit to throw ⇒ triggers onErr/UI error immediately
         el.load = vi.fn(() => {
           const err = new Error("load failed");
@@ -296,5 +296,92 @@ describe("VideoCard", () => {
       await Promise.resolve();
     });
     expect(hardTeardownSpy).toHaveBeenCalled();
+  });
+
+  it("invokes onStopLoading exactly once when unmounted with a pending load", async () => {
+    const video = {
+      id: "pending-unmount",
+      name: "pending-unmount",
+      isElectronFile: true,
+      fullPath: "C:/videos/pending-unmount.mp4",
+    };
+
+    const onStopLoading = vi.fn();
+
+    const { unmount } = render(
+      <VideoCard
+        {...baseProps}
+        video={video}
+        isVisible
+        isLoaded={false}
+        isLoading={false}
+        onStopLoading={onStopLoading}
+        scheduleInit={(fn) => fn()}
+      />
+    );
+
+    await act(async () => {});
+
+    expect(lastVideoEl).toBeTruthy();
+    expect(onStopLoading).not.toHaveBeenCalled();
+
+    await act(async () => {
+      unmount();
+    });
+
+    expect(onStopLoading).toHaveBeenCalledTimes(1);
+  });
+
+  it("releases the loading slot when capacity drops mid-load", async () => {
+    const video = {
+      id: "pending-capacity",
+      name: "pending-capacity",
+      isElectronFile: true,
+      fullPath: "C:/videos/pending-capacity.mp4",
+    };
+
+    const onStopLoading = vi.fn();
+    let canLoad = true;
+
+    const { rerender, unmount } = render(
+      <VideoCard
+        {...baseProps}
+        video={video}
+        isVisible
+        isLoaded={false}
+        isLoading={false}
+        onStopLoading={onStopLoading}
+        canLoadMoreVideos={() => canLoad}
+        scheduleInit={(fn) => fn()}
+      />
+    );
+
+    await act(async () => {});
+
+    expect(lastVideoEl).toBeTruthy();
+    expect(onStopLoading).not.toHaveBeenCalled();
+
+    canLoad = false;
+    rerender(
+      <VideoCard
+        {...baseProps}
+        video={video}
+        isVisible
+        isLoaded={false}
+        isLoading={false}
+        onStopLoading={onStopLoading}
+        canLoadMoreVideos={() => canLoad}
+        scheduleInit={(fn) => fn()}
+      />
+    );
+
+    await act(async () => {});
+    expect(onStopLoading).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      unmount();
+    });
+
+    expect(onStopLoading).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary
- ensure `runHardTeardown` notifies `onStopLoading` for pending loads and clears refs even without an attached video element
- track loading state via refs so teardown runs once and revokes pending object URLs regardless of element state
- extend VideoCard UI tests to cover pending-load unmount and mid-load capacity drop scenarios

## Testing
- npx vitest run src/components/VideoCard/__tests__/ui.test.jsx
- npx vitest run src/components/VideoCard/__tests__/retry.test.jsx

------
https://chatgpt.com/codex/tasks/task_e_68d149ae9330832cac9044cbb328a13e