### PR TITLE
Improve video loading responsiveness and scroll lookahead

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -129,21 +129,27 @@ function App() {
   const [loadedVideos, setLoadedVideos] = useState(new Set());
   const [loadingVideos, setLoadingVideos] = useState(new Set());
 
-  const { scheduleInit } = useInitGate({ perFrame: 6 });
+  const { scheduleInit } = useInitGate({ perFrame: 12 });
 
   const gridRef = useRef(null);
 
+  const [ioRootMargin, setIoRootMargin] = useState("2000px 0px");
+
   const ioRegistry = useIntersectionObserverRegistry(gridRef, {
-    rootMargin: "1600px 0px",
+    rootMargin: ioRootMargin,
     threshold: [0, 0.15],
-    nearPx: 900,
+    nearPx: 1200,
   });
 
   useEffect(() => {
     const el = gridRef.current;
     const update = () => {
       const h = el?.clientHeight || window.innerHeight;
-      ioRegistry.setNearPx(Math.max(700, Math.floor(h * 1.1)));
+      const nextNear = Math.max(1200, Math.floor(h * 1.8));
+      ioRegistry.setNearPx(nextNear);
+
+      const nextMargin = `${Math.max(2000, Math.floor(h * 3))}px 0px`;
+      setIoRootMargin((prev) => (prev === nextMargin ? prev : nextMargin));
     };
     update();
 
@@ -268,11 +274,12 @@ function App() {
     maxConcurrentPlaying,
     scrollRef: gridRef,
     progressive: {
-      initial: 120,
-      batchSize: 64,
-      intervalMs: 100,
-      pauseOnScroll: true,
+      initial: 180,
+      batchSize: 80,
+      intervalMs: 80,
+      pauseOnScroll: false,
       longTaskAdaptation: true,
+      scrollIdleMs: 80,
     },
     hadLongTaskRecently,
     isNear: ioRegistry.isNear,

--- a/src/components/VideoCard/VideoCard.jsx
+++ b/src/components/VideoCard/VideoCard.jsx
@@ -489,7 +489,7 @@ const VideoCard = memo(function VideoCard({
       }
     };
 
-    if (typeof scheduleInit === "function") {
+    if (typeof scheduleInit === "function" && !isVisiblePropRef.current) {
       scheduleInit(runInit);
     } else {
       runInit();

--- a/src/hooks/video-collection/useProgressiveList.js
+++ b/src/hooks/video-collection/useProgressiveList.js
@@ -59,9 +59,9 @@ export function useProgressiveList(
   const baseBatchSize = Number.isFinite(batchSize)
     ? Math.max(1, Math.floor(batchSize))
     : 1;
-  const [visible, setVisible] = useState(() =>
-    Math.min(safeInitial, targetCount)
-  );
+  const initialVisible = Math.min(safeInitial, targetCount);
+  const [visible, setVisible] = useState(initialVisible);
+  const visibleRef = useRef(initialVisible);
   const prevLenRef = useRef(safe.length);
   const prevTargetRef = useRef(targetCount);
   const didInitRef = useRef(false);
@@ -101,7 +101,12 @@ export function useProgressiveList(
       prevLenRef.current = len;
       prevTargetRef.current = nextTarget;
 
-      return next === current ? current : next;
+      if (next !== current) {
+        visibleRef.current = next;
+        return next;
+      }
+      visibleRef.current = current;
+      return current;
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [safe.length, maxRendered, baseBatchSize]);
@@ -236,17 +241,27 @@ export function useProgressiveList(
 
       // Skip while user actively scrolling to prioritize smoothness
       if (pauseOnScroll && isScrollingRef.current) {
-        rafId = requestAnimationFrame(schedule);
-        return;
+        const progress =
+          targetCount > 0 ? visibleRef.current / targetCount : 1;
+        if (progress >= 0.92) {
+          rafId = requestAnimationFrame(schedule);
+          return;
+        }
       }
 
       const idleCb = () => {
         if (cancelled) return;
         if (!allVisible) {
           const add = computeNextBatch();
-          setVisible((v) =>
-            v < targetCount ? Math.min(v + add, targetCount) : v
-          );
+          setVisible((v) => {
+            if (v >= targetCount) {
+              visibleRef.current = v;
+              return v;
+            }
+            const next = Math.min(v + add, targetCount);
+            if (next !== v) visibleRef.current = next;
+            return next;
+          });
         }
         // Chain next idle tick
         rafId = requestAnimationFrame(schedule);
@@ -285,9 +300,15 @@ export function useProgressiveList(
     if (allVisible) return;
 
     const timer = setInterval(() => {
-      setVisible((v) =>
-        v < targetCount ? Math.min(v + batchSize, targetCount) : v
-      );
+      setVisible((v) => {
+        if (v >= targetCount) {
+          visibleRef.current = v;
+          return v;
+        }
+        const next = Math.min(v + batchSize, targetCount);
+        if (next !== v) visibleRef.current = next;
+        return next;
+      });
     }, intervalMs);
 
     return () => clearInterval(timer);

--- a/src/hooks/video-collection/useVideoCollection.js
+++ b/src/hooks/video-collection/useVideoCollection.js
@@ -4,7 +4,11 @@ import { useProgressiveList } from "./useProgressiveList";
 import useVideoResourceManager from "./useVideoResourceManager";
 import usePlayOrchestrator from "./usePlayOrchestrator";
 
-const MAX_TILES_BUFFER = 48;
+// Render a generous number of extra tiles beyond the resource manager caps so
+// that we always have DOM ready when the user scrolls aggressively in either
+// direction. A larger buffer keeps more cards mounted without overwhelming the
+// browser because the resource manager still enforces real loading limits.
+const MAX_TILES_BUFFER = 120;
 
 export const PROGRESSIVE_DEFAULTS = {
   initial: 100,

--- a/src/hooks/video-collection/useVideoResourceManager.js
+++ b/src/hooks/video-collection/useVideoResourceManager.js
@@ -231,7 +231,10 @@ export default function useVideoResourceManager({
 
       // Always allow visible; permit small overflow over loader cap
       if (isVis) {
-        const overflow = Math.max(2, Math.floor(limits.maxConcurrentLoading * 0.25));
+        const overflow = Math.max(
+          4,
+          Math.floor(limits.maxConcurrentLoading * 0.6)
+        );
         if (_loadingVideos.size <= limits.maxConcurrentLoading + overflow) return true;
         return false;
       }

--- a/src/hooks/video-collection/useVideoResourceManager.test.js
+++ b/src/hooks/video-collection/useVideoResourceManager.test.js
@@ -79,7 +79,7 @@ describe('useVideoResourceManager (current behavior)', () => {
     expect(result.current.canLoadVideo('10')).toBe(false); // near but non-visible → blocked at cap
 
     // Push beyond overflow → now visible is also blocked
-    const overflow = Math.max(2, Math.floor(maxConcurrentLoading * 0.25));
+    const overflow = Math.max(4, Math.floor(maxConcurrentLoading * 0.6));
     for (let i = 0; i < overflow + 1; i++) loading.add(`O${i}`);
     expect(result.current.canLoadVideo('2')).toBe(false);
   });


### PR DESCRIPTION
## Summary
- expand the intersection observer lookahead and progressive rendering batches so more tiles are mounted ahead of fast scrolling
- load visible cards immediately while relaxing loader overflow for visible tiles and increasing the DOM buffer
- adjust resource manager tests for the updated overflow allowance

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d150891dfc832c973e11041dbada6e