### PR TITLE
Improve masonry prefetching and scrolling responsiveness

### DIFF
--- a/src/components/VideoCard/VideoCard.jsx
+++ b/src/components/VideoCard/VideoCard.jsx
@@ -374,12 +374,39 @@ const VideoCard = memo(function VideoCard({
         cleanupListeners();
         finishStopLoading();
         setLoaded(true);
-        videoRef.current = el;
 
         const container = videoContainerRef.current;
-        if (container && !container.contains(el) && !(el.dataset?.adopted === "modal")) {
-          container.appendChild(el);
+        if (container && !(el.dataset?.adopted === "modal")) {
+          const staleVideos = Array.from(container.querySelectorAll("video"));
+          for (const stale of staleVideos) {
+            if (!stale || stale === el) continue;
+            if (stale.dataset?.adopted === "modal") continue;
+
+            const wasCurrent = stale === videoRef.current;
+            try {
+              hardTeardownVideo(stale, {
+                listeners: wasCurrent ? persistentListenersRef.current : undefined,
+              });
+            } catch {}
+
+            if (stale.parentNode === container) {
+              try { container.removeChild(stale); } catch {}
+            } else {
+              try { stale.remove?.(); } catch {}
+            }
+
+            if (wasCurrent) {
+              videoRef.current = null;
+              persistentListenersRef.current = [];
+            }
+          }
+
+          if (!container.contains(el)) {
+            container.appendChild(el);
+          }
         }
+
+        videoRef.current = el;
       };
 
       const onErr = async (e) => {

--- a/src/components/VideoCard/VideoCard.jsx
+++ b/src/components/VideoCard/VideoCard.jsx
@@ -178,14 +178,15 @@ const VideoCard = memo(function VideoCard({
     const el = cardRef.current;
     if (!el || !observeIntersection || !unobserveIntersection) return;
 
-    const handleVisible = (nowVisible /* boolean */) => {
+    const handleVisible = (nowVisible /* boolean */, entry, info) => {
+      const isNear = info?.near ?? false;
       if (lastVisibilityRef.current !== nowVisible) {
         lastVisibilityRef.current = nowVisible;
         onVisibilityChange?.(videoId, nowVisible);
       }
 
       if (
-        nowVisible &&
+        (nowVisible || isNear) &&
         !loaded &&
         !loading &&
         !loadRequestedRef.current &&
@@ -206,7 +207,7 @@ const VideoCard = memo(function VideoCard({
   // Backup trigger if parent already flags visible
   useEffect(() => {
     if (
-      isVisible &&
+      (isVisible || isVisiblePropRef.current) &&
       !loaded &&
       !loading &&
       !loadRequestedRef.current &&
@@ -216,7 +217,7 @@ const VideoCard = memo(function VideoCard({
     ) {
       Promise.resolve().then(() => {
         if (
-          isVisible &&
+          (isVisible || isVisiblePropRef.current) &&
           !loaded &&
           !loading &&
           !loadRequestedRef.current &&
@@ -489,7 +490,7 @@ const VideoCard = memo(function VideoCard({
       }
     };
 
-    if (typeof scheduleInit === "function") {
+    if (typeof scheduleInit === "function" && !isVisiblePropRef.current) {
       scheduleInit(runInit);
     } else {
       runInit();

--- a/src/components/VideoCard/__tests__/ui.test.jsx
+++ b/src/components/VideoCard/__tests__/ui.test.jsx
@@ -236,6 +236,39 @@ describe("VideoCard", () => {
     }
   });
 
+  it("prefetches once the card is near the viewport", async () => {
+    const video = {
+      id: "near-prefetch",
+      name: "near-prefetch",
+      isElectronFile: true,
+      fullPath: "C:/videos/near.mp4",
+    };
+
+    const observeIntersection = vi.fn((el, maybeId, maybeCb) => {
+      const cb = typeof maybeId === "function" ? maybeId : maybeCb;
+      if (cb) cb(false, null, { visible: false, near: true });
+    });
+    const unobserveIntersection = vi.fn();
+    const onStartLoading = vi.fn();
+
+    render(
+      <VideoCard
+        {...baseProps}
+        video={video}
+        isVisible={false}
+        observeIntersection={observeIntersection}
+        unobserveIntersection={unobserveIntersection}
+        onStartLoading={onStartLoading}
+        scheduleInit={(fn) => fn()}
+      />
+    );
+
+    await act(async () => {});
+
+    expect(onStartLoading).toHaveBeenCalledWith(video.id);
+    expect(lastVideoEl).toBeTruthy();
+  });
+
   it("clears visibility state on unmount to avoid stale parents", async () => {
     const video = {
       id: "visible-cleanup",
@@ -247,7 +280,7 @@ describe("VideoCard", () => {
     const onVisibilityChange = vi.fn();
     const observeIntersection = vi.fn((el, maybeId, maybeCb) => {
       const cb = typeof maybeId === "function" ? maybeId : maybeCb;
-      if (cb) cb(true);
+      if (cb) cb(true, null, { visible: true, near: true });
     });
     const unobserveIntersection = vi.fn();
 

--- a/src/components/VideoCard/__tests__/ui.test.jsx
+++ b/src/components/VideoCard/__tests__/ui.test.jsx
@@ -59,7 +59,10 @@ beforeEach(() => {
 
   hardTeardownSpy = vi
     .spyOn(mediaModule, "hardTeardownVideo")
-    .mockImplementation(() => {});
+    .mockImplementation((el) => {
+      try { el?.pause?.(); } catch {}
+      try { el?.remove?.(); } catch {}
+    });
 });
 
 afterEach(() => {
@@ -267,6 +270,99 @@ describe("VideoCard", () => {
 
     expect(onStartLoading).toHaveBeenCalledWith(video.id);
     expect(lastVideoEl).toBeTruthy();
+  });
+
+  it("clears stale video elements before attaching a new playback node", async () => {
+    const video = {
+      id: "duplicate-cleanup",
+      name: "duplicate-cleanup",
+      isElectronFile: true,
+      fullPath: "C:/videos/dup.mp4",
+    };
+
+    const createdVideos = [];
+    const baseMock = document.createElement.getMockImplementation();
+    document.createElement.mockImplementation((tag, opts) => {
+      const el = baseMock(tag, opts);
+      if (tag === "video") {
+        createdVideos.push(el);
+      }
+      return el;
+    });
+
+    let canLoad = true;
+    const { rerender, container } = render(
+      <VideoCard
+        {...baseProps}
+        video={video}
+        isVisible
+        canLoadMoreVideos={() => canLoad}
+        scheduleInit={(fn) => fn()}
+      />
+    );
+
+    await act(async () => {});
+
+    const firstEl = createdVideos[0];
+    expect(firstEl).toBeTruthy();
+
+    await act(async () => {
+      firstEl.dispatchEvent?.(new Event("loadeddata"));
+    });
+
+    const cardContainer = container.querySelector(
+      `[data-video-id="${video.id}"] .video-container`
+    );
+    expect(cardContainer).toBeTruthy();
+    expect(cardContainer.querySelectorAll("video").length).toBe(1);
+
+    // Force an unload via capacity drop
+    canLoad = false;
+    rerender(
+      <VideoCard
+        {...baseProps}
+        video={video}
+        isVisible
+        canLoadMoreVideos={() => canLoad}
+        scheduleInit={(fn) => fn()}
+      />
+    );
+    await act(async () => {});
+    expect(cardContainer.querySelectorAll("video").length).toBe(0);
+
+    // Allow loads again (triggers a new createElement)
+    canLoad = true;
+    rerender(
+      <VideoCard
+        {...baseProps}
+        video={video}
+        isVisible
+        canLoadMoreVideos={() => canLoad}
+        scheduleInit={(fn) => fn()}
+      />
+    );
+
+    await act(async () => {});
+
+    const secondEl = createdVideos[1];
+    expect(secondEl).toBeTruthy();
+
+    // Simulate a stale stray <video> left behind by the previous load
+    const stale = NATIVE_CREATE_ELEMENT("video");
+    stale.pause = vi.fn();
+    stale.remove = vi.fn(function () {
+      if (this.parentNode) this.parentNode.removeChild(this);
+    });
+    cardContainer.appendChild(stale);
+    expect(cardContainer.querySelectorAll("video").length).toBe(1);
+
+    await act(async () => {
+      secondEl.dispatchEvent?.(new Event("loadeddata"));
+    });
+
+    const attachedVideos = cardContainer.querySelectorAll("video");
+    expect(attachedVideos).toHaveLength(1);
+    expect(attachedVideos[0]).toBe(secondEl);
   });
 
   it("clears visibility state on unmount to avoid stale parents", async () => {

--- a/src/hooks/ui-perf/useIntersectionObserverRegistry.js
+++ b/src/hooks/ui-perf/useIntersectionObserverRegistry.js
@@ -65,20 +65,25 @@ export default function useIntersectionObserverRegistry(
   }, []);
 
   // Observer callback: compute visible/near, then notify per-element handler
-  const handleEntries = useCallback((entries) => {
-    const rootRect = getRootRect();
-    for (const entry of entries) {
-      const el = entry.target;
-      const id = idsRef.current.get(el);
-      updateFlags(entry, id, rootRect);
+  const handleEntries = useCallback(
+    (entries) => {
+      const rootRect = getRootRect();
+      for (const entry of entries) {
+        const el = entry.target;
+        const id = idsRef.current.get(el);
+        updateFlags(entry, id, rootRect);
 
-      const cb = handlersRef.current.get(el);
-      if (cb) {
-        // We pass "visible" (true viewport) for clarity
-        cb(visibleIdsRef.current.has(id), entry);
+        const cb = handlersRef.current.get(el);
+        if (cb) {
+          const visible = visibleIdsRef.current.has(id);
+          const near = nearIdsRef.current.has(id);
+          // Pass the raw entry along with derived flags so callers can prefetch
+          cb(visible, entry, { visible, near });
+        }
       }
-    }
-  }, [getRootRect, updateFlags]);
+    },
+    [getRootRect, updateFlags]
+  );
 
   // Build the single observer (or rebuild if root/opts truly change)
   useEffect(() => {

--- a/src/hooks/video-collection/useProgressiveList.js
+++ b/src/hooks/video-collection/useProgressiveList.js
@@ -62,6 +62,14 @@ export function useProgressiveList(
   const [visible, setVisible] = useState(() =>
     Math.min(safeInitial, targetCount)
   );
+  const visibleRef = useRef(Math.min(safeInitial, targetCount));
+  useEffect(() => {
+    visibleRef.current = visible;
+  }, [visible]);
+  const targetCountRef = useRef(targetCount);
+  useEffect(() => {
+    targetCountRef.current = targetCount;
+  }, [targetCount]);
   const prevLenRef = useRef(safe.length);
   const prevTargetRef = useRef(targetCount);
   const didInitRef = useRef(false);
@@ -120,6 +128,7 @@ export function useProgressiveList(
   // State/refs used by idle strategy
   const isScrollingRef = useRef(false);
   const scrollingTimeoutRef = useRef(null);
+  const lastScrollAdvanceRef = useRef(0);
 
   // Unified “recent long task” flag (internal OR external)
   const hadLongTaskRecentlyRef = useRef(false);
@@ -151,6 +160,13 @@ export function useProgressiveList(
       scrollingTimeoutRef.current = setTimeout(() => {
         isScrollingRef.current = false;
         scrollingTimeoutRef.current = null;
+        if (dynamicBatchRef.current < baseBatchSize) {
+          dynamicBatchRef.current = Math.max(
+            baseBatchSize,
+            resolvedMinBatch
+          );
+        }
+        lastScrollAdvanceRef.current = 0;
       }, scrollIdleMs);
     };
 
@@ -235,18 +251,37 @@ export function useProgressiveList(
       if (cancelled) return;
 
       // Skip while user actively scrolling to prioritize smoothness
-      if (pauseOnScroll && isScrollingRef.current) {
-        rafId = requestAnimationFrame(schedule);
-        return;
+      const shouldThrottleScroll = pauseOnScroll && isScrollingRef.current;
+      if (shouldThrottleScroll) {
+        const backlog = Math.max(
+          0,
+          targetCountRef.current - visibleRef.current
+        );
+        if (backlog <= 0) {
+          rafId = requestAnimationFrame(schedule);
+          return;
+        }
+
+        const now =
+          typeof performance !== "undefined" && performance.now
+            ? performance.now()
+            : Date.now();
+        const minInterval = backlog > resolvedMinBatch * 2 ? 32 : 80;
+        if (now - lastScrollAdvanceRef.current < minInterval) {
+          rafId = requestAnimationFrame(schedule);
+          return;
+        }
+        lastScrollAdvanceRef.current = now;
       }
 
       const idleCb = () => {
         if (cancelled) return;
-        if (!allVisible) {
+        if (visibleRef.current < targetCountRef.current) {
           const add = computeNextBatch();
-          setVisible((v) =>
-            v < targetCount ? Math.min(v + add, targetCount) : v
-          );
+          setVisible((v) => {
+            const target = targetCountRef.current;
+            return v < target ? Math.min(v + add, target) : v;
+          });
         }
         // Chain next idle tick
         rafId = requestAnimationFrame(schedule);

--- a/src/hooks/video-collection/useVideoCollection.js
+++ b/src/hooks/video-collection/useVideoCollection.js
@@ -4,7 +4,7 @@ import { useProgressiveList } from "./useProgressiveList";
 import useVideoResourceManager from "./useVideoResourceManager";
 import usePlayOrchestrator from "./usePlayOrchestrator";
 
-const MAX_TILES_BUFFER = 48;
+const MAX_TILES_BUFFER = 96;
 
 export const PROGRESSIVE_DEFAULTS = {
   initial: 100,


### PR DESCRIPTION
## Summary
- expose "near" flags from the shared intersection observer so cards can prefetch while off screen and start immediately when visible
- relax progressive list throttling to keep rendering during fast scrolls and expand the render buffer for deeper look-ahead
- cover the new behaviour with a VideoCard near-prefetch unit test

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d150891dfc832c973e11041dbada6e