### PR TITLE
Bypass init scheduler when visible VideoCard tiles load

### DIFF
--- a/src/components/VideoCard/VideoCard.jsx
+++ b/src/components/VideoCard/VideoCard.jsx
@@ -179,6 +179,8 @@ const VideoCard = memo(function VideoCard({
     if (!el || !observeIntersection || !unobserveIntersection) return;
 
     const handleVisible = (nowVisible /* boolean */) => {
+      isVisiblePropRef.current = nowVisible;
+
       if (lastVisibilityRef.current !== nowVisible) {
         lastVisibilityRef.current = nowVisible;
         onVisibilityChange?.(videoId, nowVisible);
@@ -193,7 +195,7 @@ const VideoCard = memo(function VideoCard({
         !permanentErrorRef.current &&
         (canLoadMoreVideos?.() ?? true)
       ) {
-        loadVideo();
+        loadVideo({ immediate: true });
       }
     };
 
@@ -224,7 +226,7 @@ const VideoCard = memo(function VideoCard({
           !permanentErrorRef.current &&
           (canLoadMoreVideos?.() ?? true)
         ) {
-          loadVideo();
+          loadVideo({ immediate: true });
         }
       });
     }
@@ -320,7 +322,12 @@ const VideoCard = memo(function VideoCard({
   }, [loaded, isPlaying, isVisible, isAdoptedByModal, videoId]);
 
   // create & load <video>
-  const loadVideo = useCallback(() => {
+  const loadVideo = useCallback((options = {}) => {
+    const immediate =
+      typeof options.immediate === "boolean"
+        ? options.immediate
+        : isVisiblePropRef.current;
+
     if (loading || loaded || loadRequestedRef.current || videoRef.current) return;
     if (!(canLoadMoreVideos?.() ?? true)) return;
     if (permanentErrorRef.current) return;
@@ -332,11 +339,12 @@ const VideoCard = memo(function VideoCard({
     setLoading(true);
 
     const runInit = () => {
+      const currentlyVisible = isVisiblePropRef.current;
       const el = document.createElement("video");
       el.muted = true;
       el.loop = true;
       el.playsInline = true;
-      el.preload = isVisible ? "auto" : "metadata";
+      el.preload = currentlyVisible ? "auto" : "metadata";
       el.className = "video-element";
       el.dataset.videoId = videoId;
       el.style.width = "100%";
@@ -432,7 +440,7 @@ const VideoCard = memo(function VideoCard({
           retryAttemptsRef.current += 1;
           setTimeout(() => {
             if (
-              isVisible &&
+              isVisiblePropRef.current &&
               !loaded &&
               !loading &&
               !loadRequestedRef.current &&
@@ -448,9 +456,11 @@ const VideoCard = memo(function VideoCard({
       // Conditional load-timeout (cancelled when invisible)
       const armLoadTimeout = () => {
         clearTimeout(loadTimeoutRef.current);
-        if (isVisible) {
+        if (isVisiblePropRef.current) {
           loadTimeoutRef.current = setTimeout(() => {
-            if (isVisible) onErr({ target: { error: new Error("Loading timeout") } });
+            if (isVisiblePropRef.current) {
+              onErr({ target: { error: new Error("Loading timeout") } });
+            }
           }, 10000);
         }
       };
@@ -489,7 +499,7 @@ const VideoCard = memo(function VideoCard({
       }
     };
 
-    if (typeof scheduleInit === "function") {
+    if (typeof scheduleInit === "function" && !immediate) {
       scheduleInit(runInit);
     } else {
       runInit();
@@ -497,7 +507,6 @@ const VideoCard = memo(function VideoCard({
   }, [
     video,
     videoId,
-    isVisible,
     canLoadMoreVideos,
     loading,
     loaded,

--- a/src/components/VideoCard/__tests__/ui.test.jsx
+++ b/src/components/VideoCard/__tests__/ui.test.jsx
@@ -170,6 +170,36 @@ describe("VideoCard", () => {
     });
   });
 
+  it("starts loading immediately when visible even if scheduler queues", async () => {
+    const video = {
+      id: "visible-no-queue",
+      name: "visible-no-queue",
+      isElectronFile: true,
+      fullPath: "C:/videos/no-queue.mp4",
+    };
+
+    const scheduled = [];
+    const scheduleInit = vi.fn((fn) => {
+      scheduled.push(fn);
+    });
+
+    render(
+      <VideoCard
+        {...baseProps}
+        video={video}
+        isVisible
+        scheduleInit={scheduleInit}
+      />
+    );
+
+    await act(async () => {});
+
+    expect(scheduleInit).not.toHaveBeenCalled();
+    expect(scheduled).toHaveLength(0);
+    expect(lastVideoEl).toBeTruthy();
+    expect(lastVideoEl.load).toHaveBeenCalled();
+  });
+
   it("loads when parent marks visible even if IntersectionObserver never fires", async () => {
     // Mock IO that never calls the callback (no visibility events)
     const PrevIO = global.IntersectionObserver;


### PR DESCRIPTION
## Summary
- update the intersection observer handler to mirror visibility state on the ref before checking load gates and request immediate loads when visible
- allow `loadVideo` to bypass the init scheduler for currently visible tiles while keeping deferred scheduling for offscreen prefetches
- extend the UI tests with a regression that ensures visible cards start loading immediately even with a queuing scheduler

## Testing
- npm test -- VideoCard

------
https://chatgpt.com/codex/tasks/task_e_68d9738e0668832c83c7f8c517aeb772