### PR TITLE
Limit active media players using viewport window

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -60,6 +60,19 @@ const path = {
 
 const __DEV__ = import.meta.env.MODE !== "production";
 
+const ADMIT_OVERSCAN_PX = 1400;
+const ADMIT_FALLBACK_COUNT = 200;
+
+const setsEqual = (a, b) => {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  if (a.size !== b.size) return false;
+  for (const value of a) {
+    if (!b.has(value)) return false;
+  }
+  return true;
+};
+
 const LoadingOverlay = ({ show, stage, progress }) => {
   if (!show) return null;
   return (
@@ -128,10 +141,12 @@ function App() {
   const [visibleVideos, setVisibleVideos] = useState(new Set());
   const [loadedVideos, setLoadedVideos] = useState(new Set());
   const [loadingVideos, setLoadingVideos] = useState(new Set());
+  const [admissibleIds, setAdmissibleIds] = useState(new Set());
 
   const { scheduleInit } = useInitGate({ perFrame: 6 });
 
   const gridRef = useRef(null);
+  const positionsRef = useRef(new Map());
 
   const ioRegistry = useIntersectionObserverRegistry(gridRef, {
     rootMargin: "1600px 0px",
@@ -173,6 +188,39 @@ function App() {
   const [visualOrderedIds, setVisualOrderedIds] = useState([]);
 
   // ----- Masonry hook -----
+  const recomputeAdmissibleWindow = useCallback(() => {
+    const grid = gridRef.current;
+    const positions = positionsRef.current;
+    const next = new Set();
+
+    if (grid && positions && positions.size > 0) {
+      const viewportTop = grid.scrollTop || 0;
+      const viewportHeight = grid.clientHeight || window.innerHeight || 0;
+      const minY = Math.max(0, viewportTop - ADMIT_OVERSCAN_PX);
+      const maxY = viewportTop + viewportHeight + ADMIT_OVERSCAN_PX;
+
+      for (const [id, pos] of positions.entries()) {
+        if (!pos) continue;
+        if (pos.bottom >= minY && pos.top <= maxY) {
+          next.add(id);
+        }
+      }
+    }
+
+    if (next.size === 0 && orderedVideos.length) {
+      const fallback = Math.min(orderedVideos.length, ADMIT_FALLBACK_COUNT);
+      for (let i = 0; i < fallback; i++) {
+        next.add(orderedVideos[i].id);
+      }
+    }
+
+    for (const id of visibleVideos) next.add(id);
+    for (const id of loadingVideos) next.add(id);
+    for (const id of actualPlaying) next.add(id);
+
+    setAdmissibleIds((prev) => (setsEqual(prev, next) ? prev : next));
+  }, [orderedVideos, visibleVideos, loadingVideos, actualPlaying]);
+
   const { updateAspectRatio, onItemsChanged, setZoomClass, scheduleLayout } =
     useChunkedMasonry({
       gridRef,
@@ -183,6 +231,10 @@ function App() {
         ],
 
       onOrderChange: setVisualOrderedIds,
+      onPositionsChange: (map) => {
+        positionsRef.current = map;
+        recomputeAdmissibleWindow();
+      },
     });
 
   // MEMOIZED sorting & grouping
@@ -276,6 +328,7 @@ function App() {
     },
     hadLongTaskRecently,
     isNear: ioRegistry.isNear,
+    admissibleIds,
   });
 
   // fullscreen / context menu
@@ -643,6 +696,8 @@ function App() {
         setLoadedVideos(new Set());
         setLoadingVideos(new Set());
         setActualPlaying(new Set());
+        positionsRef.current = new Map();
+        setAdmissibleIds(new Set());
 
         setLoadingStage("Scanning for video files...");
         setLoadingProgress(30);
@@ -712,6 +767,8 @@ function App() {
       setLoadedVideos(new Set());
       setLoadingVideos(new Set());
       setActualPlaying(new Set());
+      positionsRef.current = new Map();
+      setAdmissibleIds(new Set());
     },
     [selection]
   );
@@ -857,7 +914,7 @@ function App() {
   const playingSize = actualPlaying.size;                                  
   const loadingSize = loadingVideos.size;                                   
 
-  useEffect(() => {                                                          
+  useEffect(() => {
     const id = setTimeout(() => {                                            // run after paint to avoid chaining renders
       const victims = videoCollection.performCleanup?.();
       if (Array.isArray(victims) && victims.length) {
@@ -869,7 +926,37 @@ function App() {
       }
     }, 0);
     return () => clearTimeout(id);
-  }, [maxLoaded, loadedSize, playingSize, loadingSize, videoCollection.performCleanup]); 
+  }, [
+    maxLoaded,
+    loadedSize,
+    playingSize,
+    loadingSize,
+    admissibleIds,
+    videoCollection.performCleanup,
+  ]);
+
+  useEffect(() => {
+    const grid = gridRef.current;
+    if (!grid) return;
+    let rafId = 0;
+    const handle = () => {
+      if (rafId) cancelAnimationFrame(rafId);
+      rafId = requestAnimationFrame(() => {
+        rafId = 0;
+        recomputeAdmissibleWindow();
+      });
+    };
+    grid.addEventListener("scroll", handle, { passive: true });
+    handle();
+    return () => {
+      grid.removeEventListener("scroll", handle);
+      if (rafId) cancelAnimationFrame(rafId);
+    };
+  }, [recomputeAdmissibleWindow]);
+
+  useEffect(() => {
+    recomputeAdmissibleWindow();
+  }, [orderedVideos.length, recomputeAdmissibleWindow]);
 
   return (
     <div className="app" onContextMenu={handleBackgroundContextMenu}>

--- a/src/hooks/useChunkedMasonry.js
+++ b/src/hooks/useChunkedMasonry.js
@@ -10,6 +10,7 @@ export default function useChunkedMasonry({
   chunkSize = 200,
   columnGapFallback = 12,
   onOrderChange,
+  onPositionsChange,
 }) {
   const aspectRatioCacheRef = useRef(new Map());
   const cachedGridMeasurementsRef = useRef(null);
@@ -170,7 +171,7 @@ export default function useChunkedMasonry({
           // Record position for ordering
           el.dataset.x = String(x);
           el.dataset.y = String(y);
-          positions.push({ id, x, y }); // NEW
+          positions.push({ id, x, y, height: h }); // capture height for virtualization
 
           columnHeights[minIdx] = y + h + columnGap;
         }
@@ -185,9 +186,11 @@ export default function useChunkedMasonry({
           grid.style.position = "relative";
 
           // Compute and publish visual order (top-to-bottom, then left-to-right)
+          const sortedPositions = positions.slice().sort(
+            (a, b) => a.y - b.y || a.x - b.x
+          );
           if (typeof onOrderChange === "function") {
-            positions.sort((a, b) => a.y - b.y || a.x - b.x);
-            const order = positions.map((p) => p.id);
+            const order = sortedPositions.map((p) => p.id);
             const prev = lastOrderRef.current || [];
             // shallow compare to avoid needless updates
             const changed =
@@ -197,6 +200,19 @@ export default function useChunkedMasonry({
               lastOrderRef.current = order;
               onOrderChange(order);
             }
+          }
+
+          if (typeof onPositionsChange === "function") {
+            const map = new Map();
+            for (const pos of sortedPositions) {
+              map.set(pos.id, {
+                x: pos.x,
+                top: pos.y,
+                bottom: pos.y + pos.height,
+                height: pos.height,
+              });
+            }
+            onPositionsChange(map);
           }
 
           isLayingOutRef.current = false;

--- a/src/hooks/video-collection/useVideoCollection.js
+++ b/src/hooks/video-collection/useVideoCollection.js
@@ -29,6 +29,7 @@ export default function useVideoCollection({
   progressive = {},
   hadLongTaskRecently = false,
   isNear,
+  admissibleIds,
 }) {
   const {
     initial = PROGRESSIVE_DEFAULTS.initial,
@@ -88,6 +89,7 @@ export default function useVideoCollection({
     hadLongTaskRecently,
     isNear,
     playingCap: maxConcurrentPlaying,
+    admissibleIds,
   });
 
   // Layer 3: Play orchestration (Business logic)

--- a/src/hooks/video-collection/useVideoResourceManager.js
+++ b/src/hooks/video-collection/useVideoResourceManager.js
@@ -59,7 +59,8 @@ export default function useVideoResourceManager({
   playingVideos,
   hadLongTaskRecently = false,
   isNear = () => false,
-  playingCap, 
+  playingCap,
+  admissibleIds = null,
 }) {
   // --- normalize inputs: accept Set/Array/iterable; store as Set
   const asSet = (v) =>
@@ -70,6 +71,7 @@ export default function useVideoResourceManager({
   const _loadedVideos = asSet(loadedVideos);
   const _loadingVideos = asSet(loadingVideos);
   const _playingVideos = asSet(playingVideos);
+  const _admissibleIds = asSet(admissibleIds);
 
   // --- memory sampling ---
   const [mem, setMem] = useState(() => ({
@@ -226,6 +228,12 @@ export default function useVideoResourceManager({
         if (!isVisCapBypass) return false;
       }
 
+      if (_admissibleIds.size > 0 && !_admissibleIds.has(id)) {
+        if (!_visibleVideos.has(id) && !_playingVideos.has(id) && !_loadingVideos.has(id)) {
+          return false;
+        }
+      }
+
       const isVis = _visibleVideos.has(id);
       const near = isNear ? !!isNear(id) : false;
 
@@ -266,7 +274,18 @@ export default function useVideoResourceManager({
     lastCleanupAtRef.current = now;
 
     const overBy = _loadedVideos.size - limits.maxLoaded;
-    if (overBy <= 0) return;
+
+    const forcedVictims = [];
+    if (_admissibleIds.size > 0) {
+      for (const id of _loadedVideos) {
+        if (_visibleVideos.has(id)) continue;
+        if (_playingVideos.has(id)) continue;
+        if (_admissibleIds.has(id)) continue;
+        forcedVictims.push(id);
+      }
+    }
+
+    if (overBy <= 0 && forcedVictims.length === 0) return;
 
     const loaded = Array.from(_loadedVideos);
 
@@ -275,17 +294,30 @@ export default function useVideoResourceManager({
       const vis = _visibleVideos.has(id) ? 2 : 0;
       const play = _playingVideos.has(id) ? 4 : 0;
       const near = isNear ? (isNear(id) ? 1 : 0) : 0;
-      return play + vis + near; // 0 best (not playing, not visible, not near)
+      const windowPenalty =
+        _admissibleIds.size > 0 && !_admissibleIds.has(id) ? -2 : 0;
+      return play + vis + near + windowPenalty; // windowPenalty keeps far tiles lowest
     };
 
     loaded.sort((a, b) => score(a) - score(b));
 
-    let toRemove = overBy;
-    const victims = [];
+    let toRemove = Math.max(0, overBy);
+    const forcedSet = forcedVictims.length ? new Set(forcedVictims) : null;
+    const victims = forcedVictims.length ? [...forcedVictims] : [];
+    toRemove = Math.max(0, toRemove - victims.length);
     for (const id of loaded) {
       if (toRemove <= 0) break;
       if (_playingVideos.has(id)) continue;  // never evict active playback
       if (_visibleVideos.has(id)) continue;  // keep visible loaded
+      if (forcedSet?.has(id)) continue;
+      if (_admissibleIds.size > 0 && _admissibleIds.has(id)) {
+        // Keep admissible tiles unless required for cap
+        if (forcedVictims.length === 0) {
+          // continue until we satisfy overBy strictly
+        } else {
+          continue;
+        }
+      }
       victims.push(id);
       toRemove--;
     }

--- a/src/hooks/video-collection/useVideoResourceManager.test.js
+++ b/src/hooks/video-collection/useVideoResourceManager.test.js
@@ -128,6 +128,38 @@ describe('useVideoResourceManager (current behavior)', () => {
       expect(victimsInLoaded.length).toBeLessThanOrEqual(overBy);
     }
   });
+
+  test('admissible window blocks far loads and targets them for eviction', async () => {
+    const progressiveVideos = makeVideos(40);
+    const visible = new Set(['1']);
+    const playing = new Set();
+    const loaded = new Set(['1', '2', '3', '4']);
+    const loading = new Set();
+    const admissible = new Set(['1', '2']);
+
+    const { result } = renderHook(() =>
+      useVideoResourceManager({
+        progressiveVideos,
+        visibleVideos: visible,
+        loadedVideos: loaded,
+        loadingVideos: loading,
+        playingVideos: playing,
+        isNear: () => false,
+        playingCap: 24,
+        admissibleIds: admissible,
+      })
+    );
+
+    await flushAsync();
+
+    expect(result.current.canLoadVideo('3')).toBe(false);
+    expect(result.current.canLoadVideo('1')).toBe(true);
+
+    const victims = result.current.performCleanup();
+    expect(victims).toEqual(expect.arrayContaining(['3', '4']));
+    expect(victims).not.toContain('1');
+    expect(victims).not.toContain('2');
+  });
 });
 
 describe('reportPlayerCreationFailure', () => {


### PR DESCRIPTION
## Summary
- track masonry positions so the renderer knows which tiles are near the viewport
- gate video loading/cleanup to the admissible window and clear it when folders change
- exercise the new admissible window behaviour with focused unit tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d9812bc780832c9fd9001c216eeb24