### PR TITLE
Add metadata persistence and tagging UI

### DIFF
--- a/main/database.js
+++ b/main/database.js
@@ -1,0 +1,277 @@
+const fs = require('fs');
+const path = require('path');
+const Database = require('better-sqlite3');
+const { computeFingerprint } = require('./fingerprint');
+
+let dbInstance = null;
+let metadataStoreInstance = null;
+
+function ensureDirectory(dirPath) {
+  try {
+    fs.mkdirSync(dirPath, { recursive: true });
+  } catch (error) {
+    if (error?.code !== 'EEXIST') throw error;
+  }
+}
+
+function initDatabase(app) {
+  if (dbInstance) return dbInstance;
+  const userData = app.getPath('userData');
+  ensureDirectory(userData);
+  const dbPath = path.join(userData, 'videoswarm-meta.db');
+  const db = new Database(dbPath);
+  db.pragma('journal_mode = WAL');
+  db.pragma('foreign_keys = ON');
+
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS files (
+      fingerprint TEXT PRIMARY KEY,
+      last_known_path TEXT NOT NULL,
+      size INTEGER NOT NULL,
+      created_ms INTEGER,
+      updated_at INTEGER NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS tags (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT NOT NULL UNIQUE COLLATE NOCASE
+    );
+
+    CREATE TABLE IF NOT EXISTS file_tags (
+      fingerprint TEXT NOT NULL,
+      tag_id INTEGER NOT NULL,
+      added_at INTEGER NOT NULL,
+      PRIMARY KEY (fingerprint, tag_id),
+      FOREIGN KEY (fingerprint) REFERENCES files(fingerprint) ON DELETE CASCADE,
+      FOREIGN KEY (tag_id) REFERENCES tags(id) ON DELETE CASCADE
+    );
+
+    CREATE TABLE IF NOT EXISTS ratings (
+      fingerprint TEXT PRIMARY KEY,
+      value INTEGER NOT NULL CHECK (value BETWEEN 0 AND 5),
+      updated_at INTEGER NOT NULL,
+      FOREIGN KEY (fingerprint) REFERENCES files(fingerprint) ON DELETE CASCADE
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_files_path ON files(last_known_path);
+    CREATE INDEX IF NOT EXISTS idx_file_tags_tag ON file_tags(tag_id);
+  `);
+
+  dbInstance = db;
+  return db;
+}
+
+function createMetadataStore(db) {
+  const fileUpsert = db.prepare(`
+    INSERT INTO files (fingerprint, last_known_path, size, created_ms, updated_at)
+    VALUES (@fingerprint, @last_known_path, @size, @created_ms, @updated_at)
+    ON CONFLICT(fingerprint) DO UPDATE SET
+      last_known_path=excluded.last_known_path,
+      size=excluded.size,
+      created_ms=excluded.created_ms,
+      updated_at=excluded.updated_at;
+  `);
+
+  const tagInsert = db.prepare(`
+    INSERT INTO tags (name) VALUES (?)
+    ON CONFLICT(name) DO NOTHING;
+  `);
+
+  const tagSelect = db.prepare(`SELECT id, name FROM tags WHERE name = ? COLLATE NOCASE`);
+  const tagUsage = db.prepare(`
+    SELECT t.name AS name, COUNT(ft.fingerprint) AS usageCount
+    FROM tags t
+    LEFT JOIN file_tags ft ON ft.tag_id = t.id
+    GROUP BY t.id
+    ORDER BY t.name COLLATE NOCASE;
+  `);
+
+  const tagsForFingerprint = db.prepare(`
+    SELECT t.name AS name
+    FROM tags t
+    INNER JOIN file_tags ft ON ft.tag_id = t.id
+    WHERE ft.fingerprint = ?
+    ORDER BY t.name COLLATE NOCASE;
+  `);
+
+  const addTagLink = db.prepare(`
+    INSERT INTO file_tags (fingerprint, tag_id, added_at)
+    VALUES (?, ?, ?)
+    ON CONFLICT(fingerprint, tag_id) DO NOTHING;
+  `);
+
+  const removeTagLink = db.prepare(`
+    DELETE FROM file_tags WHERE fingerprint = ? AND tag_id = ?;
+  `);
+
+  const getRating = db.prepare(`
+    SELECT value FROM ratings WHERE fingerprint = ?;
+  `);
+
+  const setRatingStmt = db.prepare(`
+    INSERT INTO ratings (fingerprint, value, updated_at)
+    VALUES (?, ?, ?)
+    ON CONFLICT(fingerprint) DO UPDATE SET value=excluded.value, updated_at=excluded.updated_at;
+  `);
+
+  const deleteRatingStmt = db.prepare(`DELETE FROM ratings WHERE fingerprint = ?;`);
+
+  const metadataCache = new Map();
+
+  function cacheKey(filePath, stats) {
+    return `${filePath}::${stats.mtimeMs || 0}::${stats.size || 0}`;
+  }
+
+  async function ensureFingerprint(filePath, stats) {
+    if (!stats) {
+      stats = await fs.promises.stat(filePath);
+    }
+    const key = cacheKey(filePath, stats);
+    const cached = metadataCache.get(key);
+    if (cached?.fingerprint) {
+      return { fingerprint: cached.fingerprint, createdMs: cached.createdMs };
+    }
+
+    const result = await computeFingerprint(filePath, stats);
+    metadataCache.set(key, { fingerprint: result.fingerprint, createdMs: result.createdMs });
+    return result;
+  }
+
+  function writeFileRecord(fingerprint, filePath, stats, createdMsOverride) {
+    const now = Date.now();
+    const createdMs = createdMsOverride ?? Math.round(
+      stats.birthtimeMs || stats.ctimeMs || stats.mtimeMs || 0
+    );
+    fileUpsert.run({
+      fingerprint,
+      last_known_path: filePath,
+      size: Number(stats.size || 0),
+      created_ms: createdMs,
+      updated_at: now,
+    });
+  }
+
+  function getTagId(name) {
+    const trimmed = (name || '').trim();
+    if (!trimmed) return null;
+    tagInsert.run(trimmed);
+    const row = tagSelect.get(trimmed);
+    return row ? row.id : null;
+  }
+
+  function mapMetadataRow(fingerprint) {
+    const tags = tagsForFingerprint.all(fingerprint).map((row) => row.name);
+    const ratingRow = getRating.get(fingerprint);
+    return {
+      tags,
+      rating: ratingRow ? ratingRow.value : null,
+    };
+  }
+
+  async function indexFile({ filePath, stats }) {
+    if (!filePath) return null;
+    const safeStats = stats || (await fs.promises.stat(filePath));
+    const { fingerprint, createdMs } = await ensureFingerprint(filePath, safeStats);
+    writeFileRecord(fingerprint, filePath, safeStats, createdMs);
+    return {
+      fingerprint,
+      ...mapMetadataRow(fingerprint),
+    };
+  }
+
+  function getMetadataForFingerprints(fingerprints) {
+    const result = {};
+    (fingerprints || []).forEach((fp) => {
+      if (!fp) return;
+      result[fp] = mapMetadataRow(fp);
+    });
+    return result;
+  }
+
+  function listTags() {
+    return tagUsage.all();
+  }
+
+  function assignTags(fingerprints, tagNames) {
+    const now = Date.now();
+    const applied = {};
+    const txn = db.transaction(() => {
+      fingerprints.forEach((fingerprint) => {
+        if (!fingerprint) return;
+        (tagNames || []).forEach((nameRaw) => {
+          const id = getTagId(nameRaw);
+          if (!id) return;
+          addTagLink.run(fingerprint, id, now);
+        });
+        applied[fingerprint] = mapMetadataRow(fingerprint);
+      });
+    });
+    txn();
+    return applied;
+  }
+
+  function removeTag(fingerprints, tagName) {
+    const name = (tagName || "").trim();
+    if (!name) return {};
+    const existing = tagSelect.get(name);
+    if (!existing?.id) return {};
+    const id = existing.id;
+    const removed = {};
+    const txn = db.transaction(() => {
+      fingerprints.forEach((fingerprint) => {
+        if (!fingerprint) return;
+        removeTagLink.run(fingerprint, id);
+        removed[fingerprint] = mapMetadataRow(fingerprint);
+      });
+    });
+    txn();
+    return removed;
+  }
+
+  function setRating(fingerprints, rating) {
+    const updates = {};
+    const now = Date.now();
+    const txn = db.transaction(() => {
+      fingerprints.forEach((fingerprint) => {
+        if (!fingerprint) return;
+        if (rating === null || rating === undefined) {
+          deleteRatingStmt.run(fingerprint);
+        } else {
+          const safeRating = Math.max(0, Math.min(5, Math.round(Number(rating))));
+          setRatingStmt.run(fingerprint, safeRating, now);
+        }
+        updates[fingerprint] = mapMetadataRow(fingerprint);
+      });
+    });
+    txn();
+    return updates;
+  }
+
+  return {
+    indexFile,
+    getMetadataForFingerprints,
+    listTags,
+    assignTags,
+    removeTag,
+    setRating,
+  };
+}
+
+function initMetadataStore(app) {
+  if (metadataStoreInstance) return metadataStoreInstance;
+  const db = initDatabase(app);
+  metadataStoreInstance = createMetadataStore(db);
+  return metadataStoreInstance;
+}
+
+function getMetadataStore() {
+  if (!metadataStoreInstance) {
+    throw new Error('Metadata store not initialised');
+  }
+  return metadataStoreInstance;
+}
+
+module.exports = {
+  initMetadataStore,
+  getMetadataStore,
+};

--- a/main/fingerprint.js
+++ b/main/fingerprint.js
@@ -1,0 +1,57 @@
+const fs = require('fs');
+const crypto = require('crypto');
+
+const DEFAULT_SAMPLE_SIZE = 64 * 1024; // 64KB front/back sampling
+
+async function readSample(handle, position, length) {
+  const buffer = Buffer.alloc(length);
+  const { bytesRead } = await handle.read(buffer, 0, length, position);
+  return buffer.subarray(0, bytesRead);
+}
+
+async function computeFingerprint(filePath, stats) {
+  const fileStats = stats || (await fs.promises.stat(filePath));
+  const size = Number(fileStats.size || 0);
+  const createdMs = Math.round(
+    fileStats.birthtimeMs || fileStats.ctimeMs || fileStats.mtimeMs || 0
+  );
+
+  const hash = crypto.createHash('sha256');
+  let handle;
+  try {
+    if (size > 0) {
+      handle = await fs.promises.open(filePath, 'r');
+      const sampleSize = Math.min(DEFAULT_SAMPLE_SIZE, size);
+      const head = await readSample(handle, 0, sampleSize);
+      hash.update(head);
+
+      if (size > sampleSize) {
+        const tail = await readSample(handle, Math.max(0, size - sampleSize), sampleSize);
+        hash.update(tail);
+      } else {
+        hash.update(head);
+      }
+    }
+  } catch (error) {
+    // If the file can't be read (locked/deleted), still produce a fingerprint fallback
+    hash.update(String(error.message || 'error'));
+  } finally {
+    if (handle) {
+      try {
+        await handle.close();
+      } catch {}
+    }
+  }
+
+  hash.update(Buffer.from(String(size)));
+  hash.update(Buffer.from(String(createdMs)));
+
+  const digest = hash.digest('hex');
+  const fingerprint = `v1-${size.toString(16)}-${createdMs}-${digest}`;
+
+  return { fingerprint, size, createdMs };
+}
+
+module.exports = {
+  computeFingerprint,
+};

--- a/preload.js
+++ b/preload.js
@@ -118,6 +118,18 @@ contextBridge.exposeInMainWorld("electronAPI", {
 
 
 
+  metadata: {
+    listTags: async () => ipcRenderer.invoke("metadata:list-tags"),
+    addTags: async (fingerprints, tagNames) =>
+      ipcRenderer.invoke("metadata:add-tags", fingerprints, tagNames),
+    removeTag: async (fingerprints, tagName) =>
+      ipcRenderer.invoke("metadata:remove-tag", fingerprints, tagName),
+    setRating: async (fingerprints, rating) =>
+      ipcRenderer.invoke("metadata:set-rating", fingerprints, rating),
+    get: async (fingerprints) =>
+      ipcRenderer.invoke("metadata:get", fingerprints),
+  },
+
   recent: {
     get: async () => ipcRenderer.invoke("recent:get"),
     add: async (folderPath) => ipcRenderer.invoke("recent:add", folderPath),

--- a/src/App.css
+++ b/src/App.css
@@ -179,6 +179,17 @@ body {
   flex-direction: column;
 }
 
+.content-region {
+  flex: 1;
+  display: flex;
+  min-height: 0;
+  position: relative;
+}
+
+.content-region .video-grid {
+  flex: 1;
+}
+
 /* Ensure React doesn't interfere with existing styles */
 * { box-sizing: border-box; }
 
@@ -206,6 +217,54 @@ body {
   /* Consolidated transitions (drop duplicate blocks later in file) */
   transition: border-color 0.2s ease, box-shadow 0.2s ease;
   will-change: opacity, transform;
+}
+
+.video-item-rating {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  background: rgba(0, 0, 0, 0.55);
+  border-radius: 999px;
+  padding: 2px 6px;
+  font-size: 0.65rem;
+  display: flex;
+  gap: 2px;
+  pointer-events: none;
+}
+
+.video-item-rating span {
+  color: rgba(255, 255, 255, 0.35);
+}
+
+.video-item-rating span.filled {
+  color: #ffd43b;
+}
+
+.video-item-tags {
+  position: absolute;
+  left: 8px;
+  bottom: 8px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  pointer-events: none;
+}
+
+.video-item-tags.with-filename {
+  bottom: 44px;
+}
+
+.video-item-tag {
+  background: rgba(0, 0, 0, 0.55);
+  color: #f5f5f5;
+  font-size: 0.65rem;
+  padding: 2px 6px;
+  border-radius: 999px;
+}
+
+.video-item-tag.more {
+  background: rgba(0, 0, 0, 0.35);
+  color: rgba(255, 255, 255, 0.7);
 }
 
 .video-item.selected { border-color: #007acc; }

--- a/src/components/ContextMenu.jsx
+++ b/src/components/ContextMenu.jsx
@@ -91,6 +91,31 @@ const ContextMenu = ({
         { id: 'copy-filename',      label: `📄 ${menuLabel('copy-filename')}`,      action: 'copy-filename' },
       );
 
+      // Metadata quick actions
+      items.push(
+        { type: 'separator' },
+        {
+          id: 'metadata-open',
+          label: '🏷️ Add or manage tags',
+          action: 'metadata:open',
+        }
+      );
+
+      const quickRatings = [5, 4, 3, 2, 1];
+      quickRatings.forEach((stars) => {
+        const glyph = '★'.repeat(stars).padEnd(5, '☆');
+        items.push({
+          id: `metadata-rate-${stars}`,
+          label: `⭐ Rate ${glyph}`,
+          action: `metadata:rate:${stars}`,
+        });
+      });
+      items.push({
+        id: 'metadata-rate-clear',
+        label: '☆ Clear rating',
+        action: 'metadata:rate:clear',
+      });
+
       // Properties (CONTEXT_ONLY)
       items.push(
         { type: 'separator' },

--- a/src/components/MetadataPanel.css
+++ b/src/components/MetadataPanel.css
@@ -1,0 +1,298 @@
+.metadata-panel {
+  width: 36px;
+  opacity: 0.9;
+  transform: translateX(0);
+  transition: width 0.25s ease, opacity 0.2s ease, transform 0.25s ease;
+  overflow: hidden;
+  border-left: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(24, 24, 24, 0.85);
+  backdrop-filter: blur(6px);
+  color: var(--color-text, #f5f5f5);
+  display: flex;
+  flex-direction: column;
+  flex-shrink: 0;
+}
+
+.metadata-panel--open {
+  width: 320px;
+  opacity: 1;
+  transform: translateX(0);
+}
+
+.metadata-panel--collapsed {
+  pointer-events: auto;
+}
+
+.metadata-panel--collapsed .metadata-panel__titles,
+.metadata-panel--collapsed .metadata-panel__content {
+  display: none;
+}
+
+.metadata-panel--collapsed .metadata-panel__header {
+  justify-content: center;
+  border-bottom: none;
+}
+
+.metadata-panel__header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.metadata-panel__toggle {
+  background: rgba(255, 255, 255, 0.08);
+  border: none;
+  color: inherit;
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.2s ease;
+}
+
+.metadata-panel__toggle:hover {
+  background: rgba(255, 255, 255, 0.16);
+}
+
+.metadata-panel__titles {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.metadata-panel__title {
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.metadata-panel__subtitle {
+  font-size: 0.75rem;
+  opacity: 0.7;
+}
+
+.metadata-panel__content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0.75rem 1rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.metadata-panel__empty-state {
+  font-size: 0.85rem;
+  opacity: 0.7;
+  padding: 0.5rem 0;
+}
+
+.metadata-panel__section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.metadata-panel__section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.metadata-panel__section-subtitle {
+  font-size: 0.75rem;
+  opacity: 0.7;
+  margin-bottom: 0.25rem;
+}
+
+.metadata-panel__badge {
+  font-size: 0.7rem;
+  padding: 0.1rem 0.4rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  color: inherit;
+}
+
+.metadata-panel__badge--accent {
+  background: rgba(81, 207, 102, 0.18);
+  color: #a9f5bc;
+}
+
+.metadata-panel__rating-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.metadata-panel__stars {
+  display: inline-flex;
+  gap: 0.25rem;
+}
+
+.metadata-panel__stars--mixed .metadata-panel__star.is-filled {
+  background: linear-gradient(135deg, #ffc107, #ff6b6b);
+}
+
+.metadata-panel__star {
+  width: 34px;
+  height: 34px;
+  border-radius: 6px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(255, 255, 255, 0.05);
+  color: #ffd43b;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.metadata-panel__star.is-filled {
+  background: rgba(255, 212, 59, 0.2);
+}
+
+.metadata-panel__star:hover {
+  transform: translateY(-1px);
+  background: rgba(255, 212, 59, 0.3);
+}
+
+.metadata-panel__star:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.metadata-panel__clear-rating {
+  background: transparent;
+  border: none;
+  color: rgba(255, 255, 255, 0.65);
+  font-size: 0.75rem;
+  cursor: pointer;
+  padding: 0.25rem 0.5rem;
+  border-radius: 6px;
+  transition: background 0.2s ease;
+}
+
+.metadata-panel__clear-rating:hover:not(:disabled) {
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.metadata-panel__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.metadata-panel__chip {
+  background: rgba(255, 255, 255, 0.08);
+  border: none;
+  color: inherit;
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.metadata-panel__chip:hover {
+  background: rgba(255, 255, 255, 0.18);
+}
+
+.metadata-panel__chip--ghost {
+  background: transparent;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.metadata-panel__chip--ghost:hover {
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.metadata-panel__chip-count {
+  font-size: 0.7rem;
+  opacity: 0.7;
+}
+
+.metadata-panel__hint {
+  font-size: 0.75rem;
+  opacity: 0.65;
+}
+
+.metadata-panel__input-row {
+  display: flex;
+  gap: 0.4rem;
+  margin-top: 0.4rem;
+}
+
+.metadata-panel__input-row input {
+  flex: 1;
+  background: rgba(0, 0, 0, 0.45);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 6px;
+  padding: 0.45rem 0.6rem;
+  color: inherit;
+  font-size: 0.8rem;
+}
+
+.metadata-panel__input-row input:focus {
+  outline: none;
+  border-color: rgba(81, 207, 102, 0.6);
+  box-shadow: 0 0 0 1px rgba(81, 207, 102, 0.3);
+}
+
+.metadata-panel__input-row button {
+  background: rgba(81, 207, 102, 0.2);
+  border: 1px solid rgba(81, 207, 102, 0.4);
+  color: #c3f7d1;
+  padding: 0.45rem 0.75rem;
+  border-radius: 6px;
+  font-size: 0.75rem;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.metadata-panel__input-row button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.metadata-panel__input-row button:not(:disabled):hover {
+  background: rgba(81, 207, 102, 0.32);
+}
+
+.metadata-panel__suggestions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  margin-top: 0.5rem;
+}
+
+.metadata-panel__suggestion {
+  background: rgba(255, 255, 255, 0.06);
+  border: none;
+  color: inherit;
+  padding: 0.25rem 0.5rem;
+  border-radius: 6px;
+  font-size: 0.7rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.metadata-panel__suggestion:hover {
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.metadata-panel__suggestion-count {
+  font-size: 0.65rem;
+  opacity: 0.7;
+}
+
+*** EOF

--- a/src/components/MetadataPanel.jsx
+++ b/src/components/MetadataPanel.jsx
@@ -1,0 +1,306 @@
+import React, { useMemo, useState, useEffect, useRef } from "react";
+import "./MetadataPanel.css";
+
+const STAR_VALUES = [1, 2, 3, 4, 5];
+
+const RatingStars = ({ value, isMixed, onSelect, onClear, disabled }) => {
+  return (
+    <div className="metadata-panel__rating-row">
+      <div
+        className={`metadata-panel__stars ${isMixed ? "metadata-panel__stars--mixed" : ""}`}
+      >
+        {STAR_VALUES.map((star) => {
+          const filled = value != null && value >= star;
+          return (
+            <button
+              key={star}
+              type="button"
+              className={`metadata-panel__star ${filled ? "is-filled" : ""}`}
+              onClick={() => !disabled && onSelect?.(star)}
+              disabled={disabled}
+              aria-label={`Rate ${star} star${star === 1 ? "" : "s"}`}
+            >
+              ★
+            </button>
+          );
+        })}
+      </div>
+      <button
+        type="button"
+        className="metadata-panel__clear-rating"
+        onClick={() => !disabled && onClear?.()}
+        disabled={disabled}
+      >
+        Clear
+      </button>
+    </div>
+  );
+};
+
+const MetadataPanel = ({
+  isOpen,
+  onToggle,
+  selectionCount,
+  selectedVideos = [],
+  availableTags = [],
+  onAddTag,
+  onRemoveTag,
+  onApplyTagToSelection,
+  onSetRating,
+  onClearRating,
+  focusToken,
+}) => {
+  const [inputValue, setInputValue] = useState("");
+  const inputRef = useRef(null);
+
+  useEffect(() => {
+    if (isOpen && focusToken) {
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    }
+  }, [focusToken, isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      setInputValue("");
+    }
+  }, [isOpen]);
+
+  const tagCounts = useMemo(() => {
+    const counts = new Map();
+    selectedVideos.forEach((video) => {
+      (video?.tags || []).forEach((tag) => {
+        const key = (tag ?? "").toString().trim();
+        if (!key) return;
+        counts.set(key, (counts.get(key) || 0) + 1);
+      });
+    });
+    return counts;
+  }, [selectedVideos]);
+
+  const sharedTags = useMemo(() => {
+    if (!selectionCount) return [];
+    const tags = [];
+    tagCounts.forEach((count, tag) => {
+      if (count === selectionCount) tags.push(tag);
+    });
+    return tags.sort((a, b) => a.localeCompare(b));
+  }, [tagCounts, selectionCount]);
+
+  const partialTags = useMemo(() => {
+    if (!selectionCount) return [];
+    const tags = [];
+    tagCounts.forEach((count, tag) => {
+      if (count > 0 && count < selectionCount) {
+        tags.push({ tag, count });
+      }
+    });
+    return tags.sort((a, b) => a.tag.localeCompare(b.tag));
+  }, [tagCounts, selectionCount]);
+
+  const ratingInfo = useMemo(() => {
+    if (!selectedVideos.length) {
+      return { value: null, mixed: false, hasAny: false };
+    }
+    const values = selectedVideos.map((video) =>
+      typeof video?.rating === "number"
+        ? Math.max(0, Math.min(5, Math.round(video.rating)))
+        : null
+    );
+    const unique = new Set(values.map((value) => (value === null ? "none" : value)));
+    if (unique.size === 1) {
+      const raw = values[0];
+      return {
+        value: raw === null ? null : raw,
+        mixed: false,
+        hasAny: raw !== null,
+      };
+    }
+    const hasAny = values.some((value) => value !== null);
+    return { value: null, mixed: true, hasAny };
+  }, [selectedVideos]);
+
+  const sharedTagSet = useMemo(() => new Set(sharedTags), [sharedTags]);
+
+  const suggestionTags = useMemo(() => {
+    if (!isOpen || !Array.isArray(availableTags)) return [];
+    const query = inputValue.trim().toLowerCase();
+    const candidates = availableTags.filter((entry) => {
+      if (!entry?.name) return false;
+      if (sharedTagSet.has(entry.name)) return false;
+      if (!query) return true;
+      return entry.name.toLowerCase().includes(query);
+    });
+    return candidates.slice(0, 6);
+  }, [availableTags, inputValue, sharedTagSet, isOpen]);
+
+  const handleTagSubmit = () => {
+    const tokens = inputValue
+      .split(",")
+      .map((token) => token.trim())
+      .filter(Boolean);
+    if (!tokens.length) return;
+    onAddTag?.(tokens);
+    setInputValue("");
+  };
+
+  const handleKeyDown = (event) => {
+    if (event.key === "Enter" || event.key === "Tab" || event.key === ",") {
+      event.preventDefault();
+      handleTagSubmit();
+    }
+  };
+
+  const panelClass = [
+    "metadata-panel",
+    isOpen ? "metadata-panel--open" : "metadata-panel--collapsed",
+    selectionCount === 0 ? "metadata-panel--empty" : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <aside className={panelClass} aria-hidden={!isOpen && selectionCount === 0}>
+      <div className="metadata-panel__header">
+        <button
+          type="button"
+          className="metadata-panel__toggle"
+          onClick={() => onToggle?.()}
+          aria-expanded={isOpen}
+          aria-label={isOpen ? "Collapse metadata panel" : "Expand metadata panel"}
+        >
+          {isOpen ? "❯" : "❮"}
+        </button>
+        <div className="metadata-panel__titles">
+          <span className="metadata-panel__title">Details</span>
+          <span className="metadata-panel__subtitle">
+            {selectionCount ? `${selectionCount} selected` : "No selection"}
+          </span>
+        </div>
+      </div>
+
+      <div className="metadata-panel__content">
+        {selectionCount === 0 ? (
+          <div className="metadata-panel__empty-state">
+            <p>Select one or more videos to tag and rate them.</p>
+          </div>
+        ) : (
+          <>
+            <section className="metadata-panel__section">
+              <div className="metadata-panel__section-header">
+                <span>Rating</span>
+                {ratingInfo.mixed ? (
+                  <span className="metadata-panel__badge">Mixed</span>
+                ) : ratingInfo.hasAny ? (
+                  <span className="metadata-panel__badge metadata-panel__badge--accent">
+                    {`${ratingInfo.value} / 5`}
+                  </span>
+                ) : (
+                  <span className="metadata-panel__badge">Not rated</span>
+                )}
+              </div>
+              <RatingStars
+                value={ratingInfo.value}
+                isMixed={ratingInfo.mixed}
+                onSelect={(val) => onSetRating?.(val)}
+                onClear={onClearRating}
+                disabled={!selectionCount}
+              />
+            </section>
+
+            <section className="metadata-panel__section">
+              <div className="metadata-panel__section-header">
+                <span>Tags</span>
+                <span className="metadata-panel__badge">
+                  {sharedTags.length ? `${sharedTags.length} applied` : "None"}
+                </span>
+              </div>
+              <div className="metadata-panel__chips">
+                {sharedTags.length === 0 ? (
+                  <span className="metadata-panel__hint">No shared tags yet.</span>
+                ) : (
+                  sharedTags.map((tag) => (
+                    <button
+                      key={tag}
+                      type="button"
+                      className="metadata-panel__chip"
+                      onClick={() => onRemoveTag?.(tag)}
+                    >
+                      <span>#{tag}</span>
+                      <span aria-hidden="true">×</span>
+                    </button>
+                  ))
+                )}
+              </div>
+
+              {partialTags.length > 0 && (
+                <div className="metadata-panel__partial-group">
+                  <div className="metadata-panel__section-subtitle">
+                    Appears on some selected clips
+                  </div>
+                  <div className="metadata-panel__chips">
+                    {partialTags.map(({ tag, count }) => (
+                      <button
+                        key={tag}
+                        type="button"
+                        className="metadata-panel__chip metadata-panel__chip--ghost"
+                        onClick={() => onApplyTagToSelection?.(tag)}
+                        title={`Apply to all (${count}/${selectionCount})`}
+                      >
+                        <span>#{tag}</span>
+                        <span className="metadata-panel__chip-count">
+                          {count}/{selectionCount}
+                        </span>
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              <div className="metadata-panel__input-row">
+                <input
+                  ref={inputRef}
+                  type="text"
+                  value={inputValue}
+                  onChange={(e) => setInputValue(e.target.value)}
+                  onKeyDown={handleKeyDown}
+                  placeholder="Add tag and press Enter"
+                  disabled={!selectionCount}
+                />
+                <button
+                  type="button"
+                  onClick={handleTagSubmit}
+                  disabled={!selectionCount || !inputValue.trim()}
+                >
+                  Add
+                </button>
+              </div>
+
+              {suggestionTags.length > 0 && (
+                <div className="metadata-panel__suggestions">
+                  {suggestionTags.map((suggestion) => (
+                    <button
+                      key={suggestion.name}
+                      type="button"
+                      className="metadata-panel__suggestion"
+                      onClick={() => onApplyTagToSelection?.(suggestion.name)}
+                    >
+                      <span>#{suggestion.name}</span>
+                      {typeof suggestion.usageCount === "number" && (
+                        <span className="metadata-panel__suggestion-count">
+                          {suggestion.usageCount}
+                        </span>
+                      )}
+                    </button>
+                  ))}
+                </div>
+              )}
+            </section>
+          </>
+        )}
+      </div>
+    </aside>
+  );
+};
+
+export default MetadataPanel;

--- a/src/components/VideoCard/VideoCard.jsx
+++ b/src/components/VideoCard/VideoCard.jsx
@@ -57,6 +57,14 @@ const VideoCard = memo(function VideoCard({
   const [errorText, setErrorText] = useState(null);
   const videoId = video.id || video.fullPath || video.name;
 
+  const ratingValue =
+    typeof video?.rating === "number" && Number.isFinite(video.rating)
+      ? Math.max(0, Math.min(5, Math.round(video.rating)))
+      : null;
+  const hasTags = Array.isArray(video?.tags) && video.tags.length > 0;
+  const tagPreview = hasTags ? video.tags.slice(0, 3) : [];
+  const extraTagCount = hasTags ? Math.max(0, video.tags.length - tagPreview.length) : 0;
+
   // Is this <video> currently adopted by the fullscreen modal?
   const isAdoptedByModal = useCallback(() => {
     const el = videoRef.current;
@@ -503,6 +511,32 @@ const VideoCard = memo(function VideoCard({
         background: "#1a1a1a",
       }}
     >
+      {ratingValue !== null && (
+        <div className="video-item-rating" title={`Rated ${ratingValue} / 5`}>
+          {Array.from({ length: 5 }).map((_, index) => (
+            <span key={index} className={index < ratingValue ? "filled" : ""}>
+              ★
+            </span>
+          ))}
+        </div>
+      )}
+
+      {hasTags && (
+        <div
+          className={`video-item-tags ${showFilenames ? "with-filename" : ""}`}
+          title={video.tags.join(", ")}
+        >
+          {tagPreview.map((tag) => (
+            <span key={tag} className="video-item-tag">
+              #{tag}
+            </span>
+          ))}
+          {extraTagCount > 0 && (
+            <span className="video-item-tag more">+{extraTagCount}</span>
+          )}
+        </div>
+      )}
+
       {loaded && videoRef.current && !isAdoptedByModal() ? (
         <div
           className="video-container"


### PR DESCRIPTION
## Summary
- add a better-sqlite3 metadata store with fingerprint-based file tracking for tags and ratings
- expose IPC bridges for listing, updating, and retrieving metadata and normalize updates in the renderer
- introduce a collapsible metadata side panel, context menu shortcuts, and video card overlays for ratings and tags

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dba28f48b8832c841ec11714c8118c