### PR TITLE
Fix electron builder icon configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "afterPack": "./scripts/linux-fix.js",
     "directories": {
       "output": "dist",
-      "buildResources": "build"
+      "buildResources": "assets"
     },
     "files": [
       "index.html",
@@ -112,7 +112,7 @@
         }
       ],
       "artifactName": "VideoSwarm-${version}-win-${arch}.${ext}",
-      "icon": "build/icon.ico",
+      "icon": "icons/videoswarm.ico",
       "publisherName": "AI Tools",
       "verifyUpdateCodeSignature": false
     },
@@ -128,7 +128,7 @@
         "deb"
       ],
       "artifactName": "VideoSwarm-${version}-linux.${ext}",
-      "icon": "build/icon.png",
+      "icon": "icons/videoswarm.png",
       "category": "Utility",
       "executableName": "video-swarm",
       "desktop": {


### PR DESCRIPTION
## Summary
- update electron-builder to source build resources from the assets directory
- point Windows and Linux packaging icons at the official VideoSwarm artwork

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_69093259a110832ca5ffd3eae6461b37