### PR TITLE
Fix masonry layout refresh when sort order changes

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1095,10 +1095,11 @@ function App() {
   ]);
 
   // === DYNAMIC ZOOM RESIZE / COUNT ===
-  // relayout when list changes
+  // relayout when ordering changes (length or sort)
   useEffect(() => {
-    if (orderedVideos.length) onItemsChanged();
-  }, [orderedVideos.length, onItemsChanged]);
+    if (!orderedIds.length) return;
+    onItemsChanged();
+  }, [orderedIds, onItemsChanged]);
 
   // aspect ratio updates from cards
     const handleVideoLoaded = useCallback(

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1095,12 +1095,6 @@ function App() {
   ]);
 
   // === DYNAMIC ZOOM RESIZE / COUNT ===
-  // relayout when ordering changes (length or sort)
-  useEffect(() => {
-    if (!orderedIds.length) return;
-    onItemsChanged();
-  }, [orderedIds, onItemsChanged]);
-
   // aspect ratio updates from cards
     const handleVideoLoaded = useCallback(
       (videoId, aspectRatio) => {

--- a/src/app/hooks/__tests__/useMasonryLayout.sort.test.jsx
+++ b/src/app/hooks/__tests__/useMasonryLayout.sort.test.jsx
@@ -1,0 +1,110 @@
+import { describe, it, expect, beforeEach, beforeAll, afterAll, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { SortKey } from "../../../sorting/sorting.js";
+import { useMasonryLayout } from "../useMasonryLayout.js";
+
+vi.mock("../../hooks/useChunkedMasonry", () => ({
+  __esModule: true,
+  default: vi.fn(() => ({
+    updateAspectRatio: vi.fn(),
+    onItemsChanged: vi.fn(),
+    setZoomClass: vi.fn(),
+    scheduleLayout: vi.fn(),
+  })),
+}));
+
+vi.mock("../../hooks/ui-perf/useIntersectionObserverRegistry", () => ({
+  __esModule: true,
+  default: vi.fn(() => ({
+    observe: vi.fn(),
+    unobserve: vi.fn(),
+    refresh: vi.fn(),
+    setNearPx: vi.fn(),
+    isNear: () => false,
+  })),
+}));
+
+describe("useMasonryLayout sorting", () => {
+  beforeAll(() => {
+    class IO {
+      constructor() {}
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+      takeRecords() { return []; }
+    }
+    global.IntersectionObserver = IO;
+  });
+
+  afterAll(() => {
+    delete global.IntersectionObserver;
+  });
+
+  const baseVideos = Array.from({ length: 10 }).map((_, idx) => ({
+    id: `id-${idx}`,
+    basename: `video-${idx}`,
+    dirname: idx < 5 ? "A" : "B",
+    createdMs: idx * 10,
+  }));
+
+  let scrollRef;
+  let gridRef;
+
+  beforeEach(() => {
+    scrollRef = { current: null };
+    gridRef = { current: null };
+  });
+
+  it("returns videos sorted by created desc across entire list", () => {
+    const { result, rerender } = renderHook(
+      ({ sortKey, sortDir }) =>
+        useMasonryLayout({
+          videos: baseVideos,
+          filteredVideos: baseVideos,
+          sortKey,
+          sortDir,
+          groupByFolders: false,
+          randomSeed: null,
+          zoomLevel: 1,
+          scrollContainerRef: scrollRef,
+          gridRef,
+        }),
+      {
+        initialProps: { sortKey: SortKey.NAME, sortDir: "asc" },
+      }
+    );
+
+    expect(result.current.orderedVideos.map((v) => v.id)).toEqual(
+      baseVideos.map((v) => v.id)
+    );
+
+    rerender({ sortKey: SortKey.CREATED, sortDir: "desc" });
+
+    expect(result.current.orderedVideos.map((v) => v.id)).toEqual(
+      [...baseVideos]
+        .sort((a, b) => b.createdMs - a.createdMs)
+        .map((v) => v.id)
+    );
+  });
+
+  it("shuffles entire list when random sort is used", () => {
+    const { result } = renderHook(() =>
+      useMasonryLayout({
+        videos: baseVideos,
+        filteredVideos: baseVideos,
+        sortKey: SortKey.RANDOM,
+        sortDir: "asc",
+        groupByFolders: false,
+        randomSeed: 123,
+        zoomLevel: 1,
+        scrollContainerRef: scrollRef,
+        gridRef,
+      })
+    );
+
+    const ids = result.current.orderedVideos.map((v) => v.id);
+    expect(ids).toHaveLength(baseVideos.length);
+    expect(new Set(ids).size).toBe(baseVideos.length);
+    expect(ids).not.toEqual(baseVideos.map((v) => v.id));
+  });
+});

--- a/src/app/hooks/useMasonryLayout.js
+++ b/src/app/hooks/useMasonryLayout.js
@@ -30,6 +30,7 @@ export function useMasonryLayout({
   });
   const [scrollTop, setScrollTop] = useState(0);
   const [visualOrderedIds, setVisualOrderedIds] = useState([]);
+  const orderSignatureRef = useRef("");
   const metadataAspectCacheRef = useRef(new Map());
   const masonryRefreshRafRef = useRef(0);
   const [ioConfig, setIoConfig] = useState({
@@ -204,6 +205,23 @@ export function useMasonryLayout({
   );
 
   const orderedIds = useMemo(() => orderedVideos.map((v) => v.id), [orderedVideos]);
+
+  useEffect(() => {
+    if (!orderedIds.length) {
+      orderSignatureRef.current = "";
+      setVisualOrderedIds([]);
+      return;
+    }
+
+    const signature = orderedIds.join("\u0001");
+    if (orderSignatureRef.current === signature) {
+      return;
+    }
+
+    orderSignatureRef.current = signature;
+    setVisualOrderedIds([]);
+    onItemsChanged();
+  }, [orderedIds, onItemsChanged, setVisualOrderedIds]);
 
   const averageAspectRatio = useMemo(() => {
     const sampleLimit = 80;


### PR DESCRIPTION
## Summary
- trigger the masonry layout refresh whenever the ordered video id list changes so the grid fully reflows after sorting

## Testing
- npm test -- --run tests --watch=false

------
https://chatgpt.com/codex/tasks/task_e_6909d10ccf78832caa9b731d3296ba63