### PR TITLE
Fix masonry relayout when sorting videos

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1096,9 +1096,24 @@ function App() {
 
   // === DYNAMIC ZOOM RESIZE / COUNT ===
   // relayout when list changes
+  const previousOrderedIdsRef = useRef([]);
   useEffect(() => {
-    if (orderedVideos.length) onItemsChanged();
-  }, [orderedVideos.length, onItemsChanged]);
+    const prev = previousOrderedIdsRef.current;
+    let hasChanged = prev.length !== orderedIds.length;
+    if (!hasChanged) {
+      for (let i = 0; i < orderedIds.length; i += 1) {
+        if (prev[i] !== orderedIds[i]) {
+          hasChanged = true;
+          break;
+        }
+      }
+    }
+
+    if (hasChanged) {
+      previousOrderedIdsRef.current = orderedIds.slice();
+      onItemsChanged();
+    }
+  }, [orderedIds, onItemsChanged]);
 
   // aspect ratio updates from cards
     const handleVideoLoaded = useCallback(

--- a/src/app/hooks/useMasonryLayout.test.js
+++ b/src/app/hooks/useMasonryLayout.test.js
@@ -1,0 +1,108 @@
+import { renderHook } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+
+import { SortKey } from "../../sorting/sorting";
+
+vi.mock("../../hooks/useChunkedMasonry", () => {
+  return {
+    __esModule: true,
+    default: vi.fn(() => ({
+      updateAspectRatio: vi.fn(),
+      onItemsChanged: vi.fn(),
+      setZoomClass: vi.fn(),
+      scheduleLayout: vi.fn(),
+    })),
+  };
+});
+
+vi.mock("../../hooks/ui-perf/useIntersectionObserverRegistry", () => {
+  return {
+    __esModule: true,
+    default: vi.fn(() => ({
+      observe: vi.fn(),
+      unobserve: vi.fn(),
+      refresh: vi.fn(),
+      setNearPx: vi.fn(),
+    })),
+  };
+});
+
+import { useMasonryLayout } from "./useMasonryLayout";
+
+const makeVideo = (id, basename, dirname, createdMs) => ({
+  id,
+  basename,
+  dirname,
+  createdMs,
+});
+
+const sampleVideos = [
+  makeVideo("a", "zeta.mp4", "folderA", 1000),
+  makeVideo("b", "beta.mp4", "folderB", 3000),
+  makeVideo("c", "alpha.mp4", "folderA", 2000),
+  makeVideo("d", "gamma.mp4", "folderB", 4000),
+  makeVideo("e", "delta.mp4", "folderC", 1500),
+];
+
+describe("useMasonryLayout sorting", () => {
+  const defaultProps = {
+    videos: sampleVideos,
+    filteredVideos: sampleVideos,
+    sortKey: SortKey.NAME,
+    sortDir: "asc",
+    groupByFolders: false,
+    randomSeed: 1234,
+    zoomLevel: 1,
+    scrollContainerRef: { current: null },
+    gridRef: { current: null },
+  };
+
+  it("sorts entire collection by name", () => {
+    const { result } = renderHook(() => useMasonryLayout(defaultProps));
+    expect(result.current.orderedVideos.map((v) => v.id)).toEqual([
+      "c",
+      "b",
+      "e",
+      "d",
+      "a",
+    ]);
+  });
+
+  it("sorts entire collection by created date", () => {
+    const { result, rerender } = renderHook(
+      (props) => useMasonryLayout(props),
+      { initialProps: defaultProps }
+    );
+
+    rerender({
+      ...defaultProps,
+      sortKey: SortKey.CREATED,
+      sortDir: "desc",
+    });
+
+    expect(result.current.orderedVideos.map((v) => v.id)).toEqual([
+      "d",
+      "b",
+      "c",
+      "e",
+      "a",
+    ]);
+  });
+
+  it("groups by folders while sorting by name", () => {
+    const { result } = renderHook(() =>
+      useMasonryLayout({
+        ...defaultProps,
+        groupByFolders: true,
+      })
+    );
+
+    expect(result.current.orderedVideos.map((v) => v.id)).toEqual([
+      "c",
+      "a",
+      "b",
+      "d",
+      "e",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- track changes in the ordered video id list so the masonry layout relayouts after sorting updates
- add unit coverage for useMasonryLayout to confirm sorting across name, created, and grouped modes

## Testing
- `npx vitest run src/App.test.jsx`
- `npx vitest run src/app/hooks/useMasonryLayout.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6909e56fb03c832cba9a6d1063a07bcc