### PR TITLE
feat: allow opening folders via drag-and-drop

### DIFF
--- a/main.js
+++ b/main.js
@@ -1436,6 +1436,56 @@ ipcMain.handle("select-folder", async () => {
   }
 });
 
+ipcMain.handle("folder-drop:open", async (event, candidatePaths = []) => {
+  const sender = event?.sender;
+  const targetWindow = sender ? BrowserWindow.fromWebContents(sender) : mainWindow;
+  const normalizeArray = Array.isArray(candidatePaths)
+    ? candidatePaths
+    : [];
+  const sanitizedPaths = normalizeArray
+    .map((entry) => (typeof entry === "string" ? entry.trim() : ""))
+    .filter((entry) => entry.length > 0);
+
+  if (!sanitizedPaths.length) {
+    return { success: false, reason: "NO_PATHS" };
+  }
+
+  let openedPath = null;
+  let extraDirectoryCount = 0;
+
+  for (const candidate of sanitizedPaths) {
+    try {
+      const stats = await fsPromises.stat(candidate);
+      if (stats.isDirectory()) {
+        if (!openedPath) {
+          openedPath = candidate;
+        } else {
+          extraDirectoryCount += 1;
+        }
+      }
+    } catch (error) {
+      console.warn(`Skipping dropped path ${candidate}:`, error?.message || error);
+    }
+  }
+
+  if (!openedPath) {
+    return { success: false, reason: "NO_DIRECTORY" };
+  }
+
+  if (targetWindow && !targetWindow.isDestroyed()) {
+    targetWindow.webContents.send("folder-selected", openedPath);
+  }
+
+  const response = { success: true, openedPath };
+  if (extraDirectoryCount > 0) {
+    response.extraDirectoryCount = extraDirectoryCount;
+    response.infoMessage = "Only the first folder was opened. Additional folders were ignored.";
+    response.infoType = "info";
+  }
+
+  return response;
+});
+
 // Handle file manager opening
 ipcMain.handle("show-item-in-folder", async (_event, filePath) => {
   try {

--- a/main.js
+++ b/main.js
@@ -1437,9 +1437,23 @@ ipcMain.handle("select-folder", async () => {
   }
 });
 
-ipcMain.handle("folder-drop:open", async (event, candidatePaths = []) => {
+ipcMain.handle("folder-drop:open", async (event, payload = []) => {
   const sender = event?.sender;
   const targetWindow = sender ? BrowserWindow.fromWebContents(sender) : mainWindow;
+  let candidatePaths = [];
+  let source = "drop";
+
+  if (Array.isArray(payload)) {
+    candidatePaths = payload;
+  } else if (payload && typeof payload === "object") {
+    if (Array.isArray(payload.paths)) {
+      candidatePaths = payload.paths;
+    }
+    if (typeof payload.source === "string" && payload.source) {
+      source = payload.source;
+    }
+  }
+
   const normalizeArray = Array.isArray(candidatePaths)
     ? candidatePaths
     : [];
@@ -1494,7 +1508,7 @@ ipcMain.handle("folder-drop:open", async (event, candidatePaths = []) => {
     targetWindow.webContents.send("folder-selected", openedPath);
   }
 
-  const response = { success: true, openedPath };
+  const response = { success: true, openedPath, source };
   if (extraDirectoryCount > 0) {
     response.extraDirectoryCount = extraDirectoryCount;
     response.infoMessage = "Only the first folder was opened. Additional folders were ignored.";

--- a/main.js
+++ b/main.js
@@ -14,6 +14,7 @@ const {
 const path = require("path");
 const fs = require("fs");
 const fsPromises = fs.promises;
+const { fileURLToPath } = require("url");
 const { getEmbeddedDragIcon } = require("./main/drag-icon");
 const { getVideoDimensions } = require("./main/videoDimensions");
 require("./main/ipc-trash")(ipcMain);
@@ -1443,7 +1444,24 @@ ipcMain.handle("folder-drop:open", async (event, candidatePaths = []) => {
     ? candidatePaths
     : [];
   const sanitizedPaths = normalizeArray
-    .map((entry) => (typeof entry === "string" ? entry.trim() : ""))
+    .map((entry) => {
+      if (typeof entry !== "string") {
+        return "";
+      }
+      const trimmed = entry.trim();
+      if (!trimmed) {
+        return "";
+      }
+      if (/^file:\/\//i.test(trimmed)) {
+        try {
+          return fileURLToPath(trimmed);
+        } catch (error) {
+          console.warn(`Skipping malformed file URI ${trimmed}:`, error);
+          return "";
+        }
+      }
+      return trimmed;
+    })
     .filter((entry) => entry.length > 0);
 
   if (!sanitizedPaths.length) {

--- a/preload.js
+++ b/preload.js
@@ -69,6 +69,11 @@ contextBridge.exposeInMainWorld("electronAPI", {
     return await ipcRenderer.invoke("select-folder");
   },
 
+  // Folder drop integration
+  openDroppedFolder: async (paths) => {
+    return await ipcRenderer.invoke("folder-drop:open", paths);
+  },
+
   // Listen for folder selection from menu
   onFolderSelected: (callback) => {
     const handler = (_event, folderPath) => {

--- a/src/App.css
+++ b/src/App.css
@@ -506,6 +506,41 @@ body {
   background: rgba(81, 207, 102, 0.1);
 }
 
+.app-drop-overlay {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+  background: rgba(81, 207, 102, 0.12);
+  border: 2px dashed rgba(81, 207, 102, 0.65);
+  color: var(--color-text);
+  z-index: 2000;
+  transition: opacity 0.2s ease;
+  animation: fadeInOverlay 0.15s ease-out;
+}
+
+.app-drop-overlay__content {
+  backdrop-filter: blur(6px);
+  background: rgba(33, 33, 33, 0.8);
+  border-radius: 14px;
+  padding: 1.5rem 2.25rem;
+  font-size: 1.1rem;
+  font-weight: 600;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
+  border: 1px solid rgba(81, 207, 102, 0.45);
+}
+
+@keyframes fadeInOverlay {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
 .selection-info {
   background: var(--color-accent);
   color: #000;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -54,6 +54,7 @@ import { useMasonryLayout } from "./app/hooks/useMasonryLayout";
 import { useMetadataActions } from "./app/hooks/useMetadataActions";
 import { useZoomControls } from "./app/hooks/useZoomControls";
 import { useElectronFolderLifecycle } from "./app/hooks/useElectronFolderLifecycle";
+import { useDroppedFolderOpener } from "./app/hooks/useDroppedFolderOpener";
 
 const clampNumber = (value, min, max) =>
   Math.max(min, Math.min(max, value));
@@ -150,7 +151,6 @@ function App() {
   const [isAboutOpen, setAboutOpen] = useState(false);
   const [profilePromptRequest, setProfilePromptRequest] = useState(null);
   const [profilePromptValue, setProfilePromptValue] = useState("");
-  const [isDragActive, setIsDragActive] = useState(false);
 
   // Video collection state
   const [actualPlaying, setActualPlaying] = useState(new Set());
@@ -173,7 +173,6 @@ function App() {
   const metadataPanelRef = useRef(null);
   const filtersButtonRef = useRef(null);
   const filtersPopoverRef = useRef(null);
-  const dragCounterRef = useRef(0);
   const refreshTagListRef = useRef(() => {});
   const applyZoomFromSettingsRef = useRef((value) => {
     setZoomLevel(clampZoomIndex(value));
@@ -758,104 +757,7 @@ function App() {
     }, 3000);
   }, []);
 
-  useEffect(() => {
-    const electronAPI = window?.electronAPI;
-    if (!electronAPI?.openDroppedFolder) {
-      return undefined;
-    }
-
-    const hasFilePayload = (event) => {
-      const types = event?.dataTransfer?.types;
-      if (!types) return false;
-      if (typeof types.includes === "function") {
-        return types.includes("Files");
-      }
-      try {
-        return Array.from(types).includes("Files");
-      } catch {
-        return false;
-      }
-    };
-
-    const resetDragState = () => {
-      dragCounterRef.current = 0;
-      setIsDragActive(false);
-    };
-
-    const handleDragEnter = (event) => {
-      if (!hasFilePayload(event)) return;
-      dragCounterRef.current += 1;
-      event.preventDefault();
-      setIsDragActive(true);
-    };
-
-    const handleDragOver = (event) => {
-      if (!hasFilePayload(event)) return;
-      event.preventDefault();
-      try {
-        event.dataTransfer.dropEffect = "copy";
-      } catch {}
-    };
-
-    const handleDragLeave = (event) => {
-      if (!hasFilePayload(event)) return;
-      event.preventDefault();
-      dragCounterRef.current = Math.max(0, dragCounterRef.current - 1);
-      if (dragCounterRef.current <= 0 || !event.relatedTarget) {
-        resetDragState();
-      }
-    };
-
-    const handleDrop = async (event) => {
-      if (!hasFilePayload(event)) return;
-      event.preventDefault();
-      const files = Array.from(event?.dataTransfer?.files || []);
-      const candidatePaths = files
-        .map((file) => (typeof file?.path === "string" ? file.path : ""))
-        .filter((value) => value.length > 0);
-
-      resetDragState();
-
-      if (!candidatePaths.length) {
-        notify("Drop a folder to open it", "info");
-        return;
-      }
-
-      try {
-        const result = await electronAPI.openDroppedFolder(candidatePaths);
-        if (result?.success) {
-          if (typeof result?.infoMessage === "string" && result.infoMessage) {
-            notify(result.infoMessage, result.infoType || "info");
-          }
-        } else if (result?.reason === "NO_DIRECTORY") {
-          notify("Drop a folder to open it", "info");
-        } else if (result?.error) {
-          notify(result.error, "error");
-        }
-      } catch (error) {
-        console.error("Failed to open dropped folder", error);
-        notify("Failed to open folder", "error");
-      }
-    };
-
-    const handleDragEnd = () => {
-      resetDragState();
-    };
-
-    window.addEventListener("dragenter", handleDragEnter);
-    window.addEventListener("dragover", handleDragOver);
-    window.addEventListener("dragleave", handleDragLeave);
-    window.addEventListener("drop", handleDrop);
-    window.addEventListener("dragend", handleDragEnd);
-
-    return () => {
-      window.removeEventListener("dragenter", handleDragEnter);
-      window.removeEventListener("dragover", handleDragOver);
-      window.removeEventListener("dragleave", handleDragLeave);
-      window.removeEventListener("drop", handleDrop);
-      window.removeEventListener("dragend", handleDragEnd);
-    };
-  }, [dragCounterRef, notify]);
+  const isDragActive = useDroppedFolderOpener({ notify });
 
   const {
     applyMetadataPatch,

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -150,6 +150,7 @@ function App() {
   const [isAboutOpen, setAboutOpen] = useState(false);
   const [profilePromptRequest, setProfilePromptRequest] = useState(null);
   const [profilePromptValue, setProfilePromptValue] = useState("");
+  const [isDragActive, setIsDragActive] = useState(false);
 
   // Video collection state
   const [actualPlaying, setActualPlaying] = useState(new Set());
@@ -172,6 +173,7 @@ function App() {
   const metadataPanelRef = useRef(null);
   const filtersButtonRef = useRef(null);
   const filtersPopoverRef = useRef(null);
+  const dragCounterRef = useRef(0);
   const refreshTagListRef = useRef(() => {});
   const applyZoomFromSettingsRef = useRef((value) => {
     setZoomLevel(clampZoomIndex(value));
@@ -756,6 +758,105 @@ function App() {
     }, 3000);
   }, []);
 
+  useEffect(() => {
+    const electronAPI = window?.electronAPI;
+    if (!electronAPI?.openDroppedFolder) {
+      return undefined;
+    }
+
+    const hasFilePayload = (event) => {
+      const types = event?.dataTransfer?.types;
+      if (!types) return false;
+      if (typeof types.includes === "function") {
+        return types.includes("Files");
+      }
+      try {
+        return Array.from(types).includes("Files");
+      } catch {
+        return false;
+      }
+    };
+
+    const resetDragState = () => {
+      dragCounterRef.current = 0;
+      setIsDragActive(false);
+    };
+
+    const handleDragEnter = (event) => {
+      if (!hasFilePayload(event)) return;
+      dragCounterRef.current += 1;
+      event.preventDefault();
+      setIsDragActive(true);
+    };
+
+    const handleDragOver = (event) => {
+      if (!hasFilePayload(event)) return;
+      event.preventDefault();
+      try {
+        event.dataTransfer.dropEffect = "copy";
+      } catch {}
+    };
+
+    const handleDragLeave = (event) => {
+      if (!hasFilePayload(event)) return;
+      event.preventDefault();
+      dragCounterRef.current = Math.max(0, dragCounterRef.current - 1);
+      if (dragCounterRef.current <= 0 || !event.relatedTarget) {
+        resetDragState();
+      }
+    };
+
+    const handleDrop = async (event) => {
+      if (!hasFilePayload(event)) return;
+      event.preventDefault();
+      const files = Array.from(event?.dataTransfer?.files || []);
+      const candidatePaths = files
+        .map((file) => (typeof file?.path === "string" ? file.path : ""))
+        .filter((value) => value.length > 0);
+
+      resetDragState();
+
+      if (!candidatePaths.length) {
+        notify("Drop a folder to open it", "info");
+        return;
+      }
+
+      try {
+        const result = await electronAPI.openDroppedFolder(candidatePaths);
+        if (result?.success) {
+          if (typeof result?.infoMessage === "string" && result.infoMessage) {
+            notify(result.infoMessage, result.infoType || "info");
+          }
+        } else if (result?.reason === "NO_DIRECTORY") {
+          notify("Drop a folder to open it", "info");
+        } else if (result?.error) {
+          notify(result.error, "error");
+        }
+      } catch (error) {
+        console.error("Failed to open dropped folder", error);
+        notify("Failed to open folder", "error");
+      }
+    };
+
+    const handleDragEnd = () => {
+      resetDragState();
+    };
+
+    window.addEventListener("dragenter", handleDragEnter);
+    window.addEventListener("dragover", handleDragOver);
+    window.addEventListener("dragleave", handleDragLeave);
+    window.addEventListener("drop", handleDrop);
+    window.addEventListener("dragend", handleDragEnd);
+
+    return () => {
+      window.removeEventListener("dragenter", handleDragEnter);
+      window.removeEventListener("dragover", handleDragOver);
+      window.removeEventListener("dragleave", handleDragLeave);
+      window.removeEventListener("drop", handleDrop);
+      window.removeEventListener("dragend", handleDragEnd);
+    };
+  }, [dragCounterRef, notify]);
+
   const {
     applyMetadataPatch,
     handleAddTags,
@@ -1328,6 +1429,13 @@ function App() {
 
   return (
     <div className="app" onContextMenu={handleBackgroundContextMenu}>
+      {isDragActive && (
+        <div className="app-drop-overlay" aria-hidden="true">
+          <div className="app-drop-overlay__content">
+            <span>Drop a folder to open it</span>
+          </div>
+        </div>
+      )}
       {!settingsLoaded ? (
         <div
           style={{

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { describe, test, expect, afterEach, vi } from "vitest";
-import { render, cleanup } from "@testing-library/react";
+import { render, cleanup, waitFor } from "@testing-library/react";
 
 const selectionMock = {
   selected: new Set(),
@@ -258,6 +258,7 @@ vi.mock("./App.css", () => ({}), { virtual: true });
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();
+  delete window.electronAPI;
 });
 
 describe("App hook composition", () => {
@@ -284,6 +285,41 @@ describe("App hook composition", () => {
 
     const zoomArgs = useZoomControlsMock.mock.calls[0][0];
     expect(zoomArgs.runWithStableAnchor).toBe(runWithStableAnchorMock);
+
+    result.unmount();
+  });
+
+  test("routes dropped folder paths through the electron bridge", async () => {
+    const openDroppedFolder = vi.fn().mockResolvedValue({ success: true });
+    window.electronAPI = { isElectron: true, openDroppedFolder };
+
+    vi.resetModules();
+    const { default: App } = await import("./App.jsx");
+
+    const result = render(<App />);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const dropEvent = new Event("drop");
+    Object.defineProperty(dropEvent, "dataTransfer", {
+      value: {
+        files: [
+          { path: "/videos/project" },
+          { path: "/videos/clip.mp4" },
+        ],
+        types: ["Files"],
+      },
+    });
+    dropEvent.preventDefault = vi.fn();
+
+    window.dispatchEvent(dropEvent);
+
+    await waitFor(() => {
+      expect(openDroppedFolder).toHaveBeenCalledWith([
+        "/videos/project",
+        "/videos/clip.mp4",
+      ]);
+    });
+    expect(dropEvent.preventDefault).toHaveBeenCalled();
 
     result.unmount();
   });

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -314,10 +314,10 @@ describe("App hook composition", () => {
     window.dispatchEvent(dropEvent);
 
     await waitFor(() => {
-      expect(openDroppedFolder).toHaveBeenCalledWith([
-        "/videos/project",
-        "/videos/clip.mp4",
-      ]);
+      expect(openDroppedFolder).toHaveBeenCalledWith({
+        paths: ["/videos/project", "/videos/clip.mp4"],
+        source: "drop",
+      });
     });
     expect(dropEvent.preventDefault).toHaveBeenCalled();
 

--- a/src/app/drag-drop/extractDroppedPaths.js
+++ b/src/app/drag-drop/extractDroppedPaths.js
@@ -1,4 +1,6 @@
 const FILE_URI_PREFIX = /^file:\/\//i;
+const URI_LIST_TYPES = ["text/uri-list", "text/x-moz-url"];
+const FALLBACK_TEXT_TYPES = ["text/plain", "text/x-vscode-resource", "text/x-moz-url-data"];
 
 function decodeFileUri(uri, platform = "unknown") {
   try {
@@ -51,6 +53,60 @@ export function normalizeDroppedPath(rawPath, platform = "unknown") {
   return trimmed;
 }
 
+function safeArrayFrom(value) {
+  if (!value) {
+    return [];
+  }
+
+  try {
+    return Array.from(value);
+  } catch (error) {
+    console.warn("Failed to iterate drop payload", error);
+    return [];
+  }
+}
+
+function parsePlainTextList(value, addPath) {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    return false;
+  }
+
+  const lines = value.split(/\r?\n/);
+  let added = false;
+  for (const rawLine of lines) {
+    const line = rawLine.trim();
+    if (!line) {
+      continue;
+    }
+    addPath(line);
+    added = true;
+  }
+  return added;
+}
+
+function parseUriList(value, addPath, { stopAfterFirst = false } = {}) {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    return false;
+  }
+
+  const lines = value.split(/\r?\n/);
+  let added = false;
+  for (const rawLine of lines) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) {
+      continue;
+    }
+
+    addPath(line);
+    added = true;
+
+    if (stopAfterFirst) {
+      break;
+    }
+  }
+  return added;
+}
+
 export function extractDroppedPaths(eventOrDataTransfer, platform = "unknown") {
   const dataTransfer = eventOrDataTransfer?.dataTransfer
     ? eventOrDataTransfer.dataTransfer
@@ -68,10 +124,11 @@ export function extractDroppedPaths(eventOrDataTransfer, platform = "unknown") {
     }
   };
 
-  const { files, items } = dataTransfer;
+  const files = dataTransfer?.files;
+  const items = dataTransfer?.items;
 
   if (files && typeof files.length === "number") {
-    for (const file of Array.from(files)) {
+    for (const file of safeArrayFrom(files)) {
       if (typeof file?.path === "string") {
         addPath(file.path);
       }
@@ -79,7 +136,7 @@ export function extractDroppedPaths(eventOrDataTransfer, platform = "unknown") {
   }
 
   if (items && typeof items.length === "number") {
-    for (const item of Array.from(items)) {
+    for (const item of safeArrayFrom(items)) {
       if (item?.kind === "file" && typeof item.getAsFile === "function") {
         const file = item.getAsFile();
         if (file && typeof file.path === "string") {
@@ -89,36 +146,65 @@ export function extractDroppedPaths(eventOrDataTransfer, platform = "unknown") {
     }
   }
 
-  if (typeof dataTransfer.getData === "function") {
-    const parseUriList = (value) => {
-      if (typeof value !== "string" || value.trim().length === 0) {
-        return;
-      }
-
-      const lines = value.split(/\r?\n/);
-      for (const line of lines) {
-        const trimmed = line.trim();
-        if (!trimmed || trimmed.startsWith("#")) {
-          continue;
+  if (typeof dataTransfer?.getData === "function") {
+    for (const type of URI_LIST_TYPES) {
+      try {
+        const consumed = parseUriList(
+          dataTransfer.getData(type),
+          addPath,
+          { stopAfterFirst: type !== "text/uri-list" }
+        );
+        if (consumed && type !== "text/uri-list" && uniquePaths.size > 0) {
+          break;
         }
-        addPath(trimmed);
+      } catch (error) {
+        console.warn(`Failed to read ${type} from drop payload`, error);
       }
-    };
-
-    try {
-      parseUriList(dataTransfer.getData("text/uri-list"));
-    } catch (error) {
-      console.warn("Failed to read text/uri-list from drop payload", error);
     }
 
     if (uniquePaths.size === 0) {
-      try {
-        parseUriList(dataTransfer.getData("text/plain"));
-      } catch (error) {
-        // Ignore text/plain errors silently
+      for (const type of FALLBACK_TEXT_TYPES) {
+        try {
+          const consumed = parsePlainTextList(dataTransfer.getData(type), addPath);
+          if (consumed && type !== "text/plain") {
+            break;
+          }
+        } catch (error) {
+          if (type === "text/plain") {
+            // Ignore plain-text errors silently to avoid noisy logs
+            continue;
+          }
+          console.warn(`Failed to read ${type} from drop payload`, error);
+        }
       }
     }
   }
 
   return Array.from(uniquePaths);
+}
+
+export function dropContainsDirectory(eventOrDataTransfer) {
+  const dataTransfer = eventOrDataTransfer?.dataTransfer
+    ? eventOrDataTransfer.dataTransfer
+    : eventOrDataTransfer;
+
+  const items = dataTransfer?.items;
+  if (!items || typeof items.length !== "number") {
+    return false;
+  }
+
+  for (const item of safeArrayFrom(items)) {
+    if (typeof item?.webkitGetAsEntry === "function") {
+      try {
+        const entry = item.webkitGetAsEntry();
+        if (entry?.isDirectory) {
+          return true;
+        }
+      } catch (error) {
+        console.warn("Failed to inspect drop entry", error);
+      }
+    }
+  }
+
+  return false;
 }

--- a/src/app/drag-drop/extractDroppedPaths.js
+++ b/src/app/drag-drop/extractDroppedPaths.js
@@ -1,0 +1,124 @@
+const FILE_URI_PREFIX = /^file:\/\//i;
+
+function decodeFileUri(uri, platform = "unknown") {
+  try {
+    const url = new URL(uri);
+    if (url.protocol !== "file:") {
+      return "";
+    }
+
+    const hostname = url.hostname || "";
+    let pathname = decodeURIComponent(url.pathname || "");
+
+    if (platform === "win32") {
+      if (hostname) {
+        const normalizedPath = pathname.replace(/\//g, "\\");
+        return `\\\\${hostname}${normalizedPath}`;
+      }
+
+      if (pathname.startsWith("/")) {
+        pathname = pathname.slice(1);
+      }
+
+      return pathname.replace(/\//g, "\\");
+    }
+
+    if (hostname) {
+      return `//${hostname}${pathname}`;
+    }
+
+    return pathname || "/";
+  } catch (error) {
+    console.warn("Failed to decode file URI", uri, error);
+    return "";
+  }
+}
+
+export function normalizeDroppedPath(rawPath, platform = "unknown") {
+  if (typeof rawPath !== "string") {
+    return "";
+  }
+
+  const trimmed = rawPath.trim();
+  if (!trimmed) {
+    return "";
+  }
+
+  if (FILE_URI_PREFIX.test(trimmed)) {
+    return decodeFileUri(trimmed, platform);
+  }
+
+  return trimmed;
+}
+
+export function extractDroppedPaths(eventOrDataTransfer, platform = "unknown") {
+  const dataTransfer = eventOrDataTransfer?.dataTransfer
+    ? eventOrDataTransfer.dataTransfer
+    : eventOrDataTransfer;
+
+  if (!dataTransfer) {
+    return [];
+  }
+
+  const uniquePaths = new Set();
+  const addPath = (value) => {
+    const normalized = normalizeDroppedPath(value, platform);
+    if (normalized) {
+      uniquePaths.add(normalized);
+    }
+  };
+
+  const { files, items } = dataTransfer;
+
+  if (files && typeof files.length === "number") {
+    for (const file of Array.from(files)) {
+      if (typeof file?.path === "string") {
+        addPath(file.path);
+      }
+    }
+  }
+
+  if (items && typeof items.length === "number") {
+    for (const item of Array.from(items)) {
+      if (item?.kind === "file" && typeof item.getAsFile === "function") {
+        const file = item.getAsFile();
+        if (file && typeof file.path === "string") {
+          addPath(file.path);
+        }
+      }
+    }
+  }
+
+  if (typeof dataTransfer.getData === "function") {
+    const parseUriList = (value) => {
+      if (typeof value !== "string" || value.trim().length === 0) {
+        return;
+      }
+
+      const lines = value.split(/\r?\n/);
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed || trimmed.startsWith("#")) {
+          continue;
+        }
+        addPath(trimmed);
+      }
+    };
+
+    try {
+      parseUriList(dataTransfer.getData("text/uri-list"));
+    } catch (error) {
+      console.warn("Failed to read text/uri-list from drop payload", error);
+    }
+
+    if (uniquePaths.size === 0) {
+      try {
+        parseUriList(dataTransfer.getData("text/plain"));
+      } catch (error) {
+        // Ignore text/plain errors silently
+      }
+    }
+  }
+
+  return Array.from(uniquePaths);
+}

--- a/src/app/drag-drop/extractDroppedPaths.test.js
+++ b/src/app/drag-drop/extractDroppedPaths.test.js
@@ -1,5 +1,9 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { extractDroppedPaths, normalizeDroppedPath } from "./extractDroppedPaths";
+import {
+  dropContainsDirectory,
+  extractDroppedPaths,
+  normalizeDroppedPath,
+} from "./extractDroppedPaths";
 
 describe("normalizeDroppedPath", () => {
   it("returns empty string for non-string", () => {
@@ -92,5 +96,68 @@ describe("extractDroppedPaths", () => {
     };
 
     expect(extractDroppedPaths({ dataTransfer }, "darwin")).toEqual([]);
+  });
+
+  it("consumes additional uri-like payloads", () => {
+    const dataTransfer = {
+      files: [],
+      items: [],
+      getData: vi.fn((type) =>
+        type === "text/x-moz-url" ? "file:///videos/alt\nVideos" : ""
+      ),
+    };
+
+    expect(extractDroppedPaths({ dataTransfer }, "darwin")).toEqual([
+      "/videos/alt",
+    ]);
+  });
+
+  it("parses plain-text windows paths", () => {
+    const dataTransfer = {
+      files: [],
+      items: [],
+      getData: vi.fn((type) =>
+        type === "text/plain" ? "C:\\Users\\demo\\Videos" : ""
+      ),
+    };
+
+    expect(extractDroppedPaths({ dataTransfer }, "win32")).toEqual([
+      "C:\\Users\\demo\\Videos",
+    ]);
+  });
+});
+
+describe("dropContainsDirectory", () => {
+  it("returns false without items", () => {
+    expect(dropContainsDirectory({})).toBe(false);
+  });
+
+  it("detects directory entries", () => {
+    const dataTransfer = {
+      items: [
+        {
+          webkitGetAsEntry: () => ({ isDirectory: false }),
+        },
+        {
+          webkitGetAsEntry: () => ({ isDirectory: true }),
+        },
+      ],
+    };
+
+    expect(dropContainsDirectory({ dataTransfer })).toBe(true);
+  });
+
+  it("handles inspection errors gracefully", () => {
+    const dataTransfer = {
+      items: [
+        {
+          webkitGetAsEntry: () => {
+            throw new Error("boom");
+          },
+        },
+      ],
+    };
+
+    expect(dropContainsDirectory({ dataTransfer })).toBe(false);
   });
 });

--- a/src/app/drag-drop/extractDroppedPaths.test.js
+++ b/src/app/drag-drop/extractDroppedPaths.test.js
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { extractDroppedPaths, normalizeDroppedPath } from "./extractDroppedPaths";
+
+describe("normalizeDroppedPath", () => {
+  it("returns empty string for non-string", () => {
+    expect(normalizeDroppedPath(null)).toBe("");
+  });
+
+  it("trims whitespace-only entries", () => {
+    expect(normalizeDroppedPath("   ")).toBe("");
+  });
+
+  it("passes through absolute paths", () => {
+    expect(normalizeDroppedPath("/Users/demo/Videos", "darwin")).toBe(
+      "/Users/demo/Videos"
+    );
+  });
+
+  it("converts file URIs on mac/linux", () => {
+    expect(
+      normalizeDroppedPath("file:///Users/demo/Videos", "darwin")
+    ).toBe("/Users/demo/Videos");
+  });
+
+  it("converts file URIs on windows", () => {
+    expect(
+      normalizeDroppedPath("file:///C:/Users/demo/Videos", "win32")
+    ).toBe("C:\\Users\\demo\\Videos");
+  });
+
+  it("converts windows network shares", () => {
+    expect(
+      normalizeDroppedPath("file://server/share/Videos", "win32")
+    ).toBe("\\\\server\\share\\Videos");
+  });
+});
+
+describe("extractDroppedPaths", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("extracts file paths from FileList", () => {
+    const event = {
+      dataTransfer: {
+        files: [{ path: "/videos/one" }, { path: "" }],
+      },
+    };
+
+    expect(extractDroppedPaths(event, "darwin")).toEqual(["/videos/one"]);
+  });
+
+  it("de-dupes paths across sources", () => {
+    const dataTransfer = {
+      files: [{ path: "/videos/one" }],
+      items: [
+        {
+          kind: "file",
+          getAsFile: () => ({ path: "/videos/one" }),
+        },
+      ],
+      getData: vi.fn(() => "file:///videos/one"),
+    };
+
+    expect(extractDroppedPaths({ dataTransfer }, "darwin")).toEqual([
+      "/videos/one",
+    ]);
+    expect(dataTransfer.getData).toHaveBeenCalledWith("text/uri-list");
+  });
+
+  it("falls back to uri-list payloads when FileList is empty", () => {
+    const dataTransfer = {
+      files: [],
+      items: [],
+      getData: vi.fn((type) =>
+        type === "text/uri-list" ? "file:///videos/one\n#comment" : ""
+      ),
+    };
+
+    expect(extractDroppedPaths({ dataTransfer }, "darwin")).toEqual([
+      "/videos/one",
+    ]);
+  });
+
+  it("ignores uri parsing errors", () => {
+    const dataTransfer = {
+      files: [],
+      items: [],
+      getData: vi.fn(() => {
+        throw new Error("nope");
+      }),
+    };
+
+    expect(extractDroppedPaths({ dataTransfer }, "darwin")).toEqual([]);
+  });
+});

--- a/src/app/hooks/useDroppedFolderOpener.js
+++ b/src/app/hooks/useDroppedFolderOpener.js
@@ -1,10 +1,26 @@
 import { useEffect, useRef, useState } from "react";
-import { extractDroppedPaths } from "../drag-drop/extractDroppedPaths";
+import {
+  dropContainsDirectory,
+  extractDroppedPaths,
+} from "../drag-drop/extractDroppedPaths";
 
 const NO_DIRECTORY_MESSAGE =
   "Dropped items didn't contain a folder. Drop a folder to open it.";
 const NO_PATHS_MESSAGE =
   "We couldn't read that drop. Drop a folder to open it.";
+const PLATFORM_PATH_WARNING = {
+  win32:
+    "Windows didn't share the folder's location with VideoSwarm, so we couldn't open it automatically. Please use Open Folder and pick it manually.",
+  linux:
+    "Your file manager didn't share the folder's location with VideoSwarm, so we couldn't open it automatically. Please use Open Folder and pick it manually.",
+};
+
+function missingPathMessage(platform = "unknown") {
+  if (platform && PLATFORM_PATH_WARNING[platform]) {
+    return PLATFORM_PATH_WARNING[platform];
+  }
+  return "Your system didn't share the folder's location with VideoSwarm, so we couldn't open it automatically. Please use Open Folder and pick it manually.";
+}
 
 function hasFilePayload(event) {
   const types = event?.dataTransfer?.types;
@@ -79,16 +95,53 @@ export function useDroppedFolderOpener({ notify }) {
       }
 
       event.preventDefault();
+      const containsDirectory = dropContainsDirectory(event);
       const droppedPaths = extractDroppedPaths(event, platform);
       resetDragState();
 
       if (!droppedPaths.length) {
-        notify?.(NO_PATHS_MESSAGE, "info");
+        if (containsDirectory) {
+          notify?.(missingPathMessage(platform), "warning");
+          const selectFolder = electronAPI.selectFolder;
+          if (typeof selectFolder === "function") {
+            try {
+              const selection = await selectFolder();
+              if (selection?.success && selection.folderPath) {
+                const fallbackResult = await electronAPI.openDroppedFolder({
+                  paths: [selection.folderPath],
+                  source: "drop-fallback",
+                });
+                if (!fallbackResult?.success) {
+                  if (fallbackResult?.reason === "NO_DIRECTORY") {
+                    notify?.(NO_DIRECTORY_MESSAGE, "info");
+                  } else if (fallbackResult?.reason === "NO_PATHS") {
+                    notify?.(missingPathMessage(platform), "warning");
+                  } else if (fallbackResult?.error) {
+                    notify?.(fallbackResult.error, "error");
+                  } else {
+                    notify?.("Failed to open folder", "error");
+                  }
+                }
+              }
+            } catch (fallbackError) {
+              console.error(
+                "Failed to open folder through fallback picker",
+                fallbackError
+              );
+              notify?.("Failed to open folder", "error");
+            }
+          }
+        } else {
+          notify?.(NO_PATHS_MESSAGE, "info");
+        }
         return;
       }
 
       try {
-        const result = await electronAPI.openDroppedFolder(droppedPaths);
+        const result = await electronAPI.openDroppedFolder({
+          paths: droppedPaths,
+          source: "drop",
+        });
         if (result?.success) {
           if (typeof result?.infoMessage === "string" && result.infoMessage) {
             notify?.(result.infoMessage, result.infoType || "info");
@@ -99,7 +152,7 @@ export function useDroppedFolderOpener({ notify }) {
         if (result?.reason === "NO_DIRECTORY") {
           notify?.(NO_DIRECTORY_MESSAGE, "info");
         } else if (result?.reason === "NO_PATHS") {
-          notify?.(NO_PATHS_MESSAGE, "info");
+          notify?.(missingPathMessage(platform), "warning");
         } else if (result?.error) {
           notify?.(result.error, "error");
         } else {

--- a/src/app/hooks/useDroppedFolderOpener.js
+++ b/src/app/hooks/useDroppedFolderOpener.js
@@ -1,0 +1,136 @@
+import { useEffect, useRef, useState } from "react";
+import { extractDroppedPaths } from "../drag-drop/extractDroppedPaths";
+
+const NO_DIRECTORY_MESSAGE =
+  "Dropped items didn't contain a folder. Drop a folder to open it.";
+const NO_PATHS_MESSAGE =
+  "We couldn't read that drop. Drop a folder to open it.";
+
+function hasFilePayload(event) {
+  const types = event?.dataTransfer?.types;
+  if (!types) {
+    return false;
+  }
+
+  if (typeof types.includes === "function") {
+    return types.includes("Files");
+  }
+
+  try {
+    return Array.from(types).includes("Files");
+  } catch (error) {
+    console.warn("Failed to inspect drag types", error);
+    return false;
+  }
+}
+
+export function useDroppedFolderOpener({ notify }) {
+  const [isDragActive, setIsDragActive] = useState(false);
+  const dragCounterRef = useRef(0);
+
+  useEffect(() => {
+    const electronAPI = window?.electronAPI;
+    if (!electronAPI?.openDroppedFolder) {
+      return undefined;
+    }
+
+    const platform = electronAPI.platform || navigator?.platform || "unknown";
+
+    const resetDragState = () => {
+      dragCounterRef.current = 0;
+      setIsDragActive(false);
+    };
+
+    const handleDragEnter = (event) => {
+      if (!hasFilePayload(event)) {
+        return;
+      }
+      dragCounterRef.current += 1;
+      event.preventDefault();
+      setIsDragActive(true);
+    };
+
+    const handleDragOver = (event) => {
+      if (!hasFilePayload(event)) {
+        return;
+      }
+      event.preventDefault();
+      try {
+        event.dataTransfer.dropEffect = "copy";
+      } catch (error) {
+        // Ignore dropEffect assignment issues
+      }
+    };
+
+    const handleDragLeave = (event) => {
+      if (!hasFilePayload(event)) {
+        return;
+      }
+      event.preventDefault();
+      dragCounterRef.current = Math.max(0, dragCounterRef.current - 1);
+      if (dragCounterRef.current <= 0 || !event.relatedTarget) {
+        resetDragState();
+      }
+    };
+
+    const handleDrop = async (event) => {
+      if (!hasFilePayload(event)) {
+        return;
+      }
+
+      event.preventDefault();
+      const droppedPaths = extractDroppedPaths(event, platform);
+      resetDragState();
+
+      if (!droppedPaths.length) {
+        notify?.(NO_PATHS_MESSAGE, "info");
+        return;
+      }
+
+      try {
+        const result = await electronAPI.openDroppedFolder(droppedPaths);
+        if (result?.success) {
+          if (typeof result?.infoMessage === "string" && result.infoMessage) {
+            notify?.(result.infoMessage, result.infoType || "info");
+          }
+          return;
+        }
+
+        if (result?.reason === "NO_DIRECTORY") {
+          notify?.(NO_DIRECTORY_MESSAGE, "info");
+        } else if (result?.reason === "NO_PATHS") {
+          notify?.(NO_PATHS_MESSAGE, "info");
+        } else if (result?.error) {
+          notify?.(result.error, "error");
+        } else {
+          notify?.("Failed to open folder", "error");
+        }
+      } catch (error) {
+        console.error("Failed to open dropped folder", error);
+        notify?.("Failed to open folder", "error");
+      }
+    };
+
+    const handleDragEnd = () => {
+      resetDragState();
+    };
+
+    window.addEventListener("dragenter", handleDragEnter);
+    window.addEventListener("dragover", handleDragOver);
+    window.addEventListener("dragleave", handleDragLeave);
+    window.addEventListener("drop", handleDrop);
+    window.addEventListener("dragend", handleDragEnd);
+
+    return () => {
+      window.removeEventListener("dragenter", handleDragEnter);
+      window.removeEventListener("dragover", handleDragOver);
+      window.removeEventListener("dragleave", handleDragLeave);
+      window.removeEventListener("drop", handleDrop);
+      window.removeEventListener("dragend", handleDragEnd);
+    };
+  }, [notify]);
+
+  return isDragActive;
+}
+
+export default useDroppedFolderOpener;

--- a/src/app/hooks/useDroppedFolderOpener.test.jsx
+++ b/src/app/hooks/useDroppedFolderOpener.test.jsx
@@ -16,7 +16,10 @@ function HookHarness({ notify }) {
 describe("useDroppedFolderOpener", () => {
   it("invokes openDroppedFolder with extracted paths", async () => {
     const openDroppedFolder = vi.fn().mockResolvedValue({ success: true });
-    window.electronAPI = { openDroppedFolder, platform: "darwin" };
+    window.electronAPI = {
+      openDroppedFolder,
+      platform: "darwin",
+    };
     const notify = vi.fn();
 
     render(<HookHarness notify={notify} />);
@@ -27,6 +30,7 @@ describe("useDroppedFolderOpener", () => {
         files: [{ path: "file:///Users/demo/Videos" }],
         types: ["Files"],
         getData: vi.fn(() => ""),
+        items: [],
       },
     });
     dropEvent.preventDefault = vi.fn();
@@ -34,9 +38,10 @@ describe("useDroppedFolderOpener", () => {
     window.dispatchEvent(dropEvent);
 
     await waitFor(() => {
-      expect(openDroppedFolder).toHaveBeenCalledWith([
-        "/Users/demo/Videos",
-      ]);
+      expect(openDroppedFolder).toHaveBeenCalledWith({
+        paths: ["/Users/demo/Videos"],
+        source: "drop",
+      });
     });
 
     expect(notify).not.toHaveBeenCalled();
@@ -46,7 +51,10 @@ describe("useDroppedFolderOpener", () => {
     const openDroppedFolder = vi
       .fn()
       .mockResolvedValue({ success: false, reason: "NO_DIRECTORY" });
-    window.electronAPI = { openDroppedFolder, platform: "darwin" };
+    window.electronAPI = {
+      openDroppedFolder,
+      platform: "darwin",
+    };
     const notify = vi.fn();
 
     render(<HookHarness notify={notify} />);
@@ -57,6 +65,7 @@ describe("useDroppedFolderOpener", () => {
         files: [{ path: "/Users/demo/file.mp4" }],
         types: ["Files"],
         getData: vi.fn(() => ""),
+        items: [],
       },
     });
     dropEvent.preventDefault = vi.fn();
@@ -68,6 +77,87 @@ describe("useDroppedFolderOpener", () => {
         "Dropped items didn't contain a folder. Drop a folder to open it.",
         "info"
       );
+    });
+  });
+
+  it("offers a picker fallback when the path is missing but a directory is detected", async () => {
+    const openDroppedFolder = vi
+      .fn()
+      .mockResolvedValue({ success: true });
+    const selectFolder = vi.fn().mockResolvedValue({
+      success: true,
+      folderPath: "/Users/demo/Picked",
+    });
+    window.electronAPI = {
+      openDroppedFolder,
+      selectFolder,
+      platform: "win32",
+    };
+    const notify = vi.fn();
+
+    render(<HookHarness notify={notify} />);
+
+    const dropEvent = new Event("drop");
+    Object.defineProperty(dropEvent, "dataTransfer", {
+      value: {
+        files: [],
+        items: [
+          {
+            webkitGetAsEntry: () => ({ isDirectory: true }),
+          },
+        ],
+        types: {
+          includes: (value) => value === "Files",
+        },
+        getData: vi.fn(() => ""),
+      },
+    });
+    dropEvent.preventDefault = vi.fn();
+
+    window.dispatchEvent(dropEvent);
+
+    await waitFor(() => {
+      expect(selectFolder).toHaveBeenCalled();
+      expect(notify).toHaveBeenCalledWith(
+        "Windows didn't share the folder's location with VideoSwarm, so we couldn't open it automatically. Please use Open Folder and pick it manually.",
+        "warning"
+      );
+      expect(openDroppedFolder).toHaveBeenCalledWith({
+        paths: ["/Users/demo/Picked"],
+        source: "drop-fallback",
+      });
+    });
+  });
+
+  it("explains missing paths when no directory is detected", async () => {
+    const openDroppedFolder = vi.fn();
+    const notify = vi.fn();
+    window.electronAPI = {
+      openDroppedFolder,
+      platform: "linux",
+    };
+
+    render(<HookHarness notify={notify} />);
+
+    const dropEvent = new Event("drop");
+    Object.defineProperty(dropEvent, "dataTransfer", {
+      value: {
+        files: [],
+        items: [],
+        types: ["Files"],
+        getData: vi.fn(() => ""),
+      },
+    });
+    dropEvent.preventDefault = vi.fn();
+
+    window.dispatchEvent(dropEvent);
+
+    await waitFor(() => {
+      expect(notify).toHaveBeenCalledWith(
+        "We couldn't read that drop. Drop a folder to open it.",
+        "info"
+      );
+      expect(openDroppedFolder).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/app/hooks/useDroppedFolderOpener.test.jsx
+++ b/src/app/hooks/useDroppedFolderOpener.test.jsx
@@ -1,0 +1,73 @@
+import React from "react";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, cleanup, waitFor } from "@testing-library/react";
+import { useDroppedFolderOpener } from "./useDroppedFolderOpener";
+
+afterEach(() => {
+  cleanup();
+  delete window.electronAPI;
+});
+
+function HookHarness({ notify }) {
+  useDroppedFolderOpener({ notify });
+  return null;
+}
+
+describe("useDroppedFolderOpener", () => {
+  it("invokes openDroppedFolder with extracted paths", async () => {
+    const openDroppedFolder = vi.fn().mockResolvedValue({ success: true });
+    window.electronAPI = { openDroppedFolder, platform: "darwin" };
+    const notify = vi.fn();
+
+    render(<HookHarness notify={notify} />);
+
+    const dropEvent = new Event("drop");
+    Object.defineProperty(dropEvent, "dataTransfer", {
+      value: {
+        files: [{ path: "file:///Users/demo/Videos" }],
+        types: ["Files"],
+        getData: vi.fn(() => ""),
+      },
+    });
+    dropEvent.preventDefault = vi.fn();
+
+    window.dispatchEvent(dropEvent);
+
+    await waitFor(() => {
+      expect(openDroppedFolder).toHaveBeenCalledWith([
+        "/Users/demo/Videos",
+      ]);
+    });
+
+    expect(notify).not.toHaveBeenCalled();
+  });
+
+  it("notifies when no directories are present", async () => {
+    const openDroppedFolder = vi
+      .fn()
+      .mockResolvedValue({ success: false, reason: "NO_DIRECTORY" });
+    window.electronAPI = { openDroppedFolder, platform: "darwin" };
+    const notify = vi.fn();
+
+    render(<HookHarness notify={notify} />);
+
+    const dropEvent = new Event("drop");
+    Object.defineProperty(dropEvent, "dataTransfer", {
+      value: {
+        files: [{ path: "/Users/demo/file.mp4" }],
+        types: ["Files"],
+        getData: vi.fn(() => ""),
+      },
+    });
+    dropEvent.preventDefault = vi.fn();
+
+    window.dispatchEvent(dropEvent);
+
+    await waitFor(() => {
+      expect(notify).toHaveBeenCalledWith(
+        "Dropped items didn't contain a folder. Drop a folder to open it.",
+        "info"
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add renderer-wide drag-and-drop handling that forwards folder paths to the existing open-folder lifecycle and shows a visual overlay
- validate dropped directories in the main process and expose a preload bridge for the renderer
- cover the new drag-and-drop flow with unit tests

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911d7069578832c875e860e0be14a64)