### PR TITLE
Improve shift-click box selection accuracy

### DIFF
--- a/src/components/VideoCard/VideoCard.jsx
+++ b/src/components/VideoCard/VideoCard.jsx
@@ -689,14 +689,15 @@ const VideoCard = memo(function VideoCard({
   // UI handlers (unchanged)
   const handleClick = useCallback((e) => {
     e.stopPropagation();
+    const pointer = { clientX: e.clientX, clientY: e.clientY };
     if (clickTimeoutRef.current) {
       clearTimeout(clickTimeoutRef.current);
       clickTimeoutRef.current = null;
-      onSelect?.(videoId, e.ctrlKey || e.metaKey, e.shiftKey, true);
+      onSelect?.(videoId, e.ctrlKey || e.metaKey, e.shiftKey, true, pointer);
       return;
     }
     clickTimeoutRef.current = setTimeout(() => {
-      onSelect?.(videoId, e.ctrlKey || e.metaKey, e.shiftKey, false);
+      onSelect?.(videoId, e.ctrlKey || e.metaKey, e.shiftKey, false, pointer);
       clickTimeoutRef.current = null;
     }, 300);
   }, [onSelect, videoId]);

--- a/src/hooks/selection/useCardSelection.js
+++ b/src/hooks/selection/useCardSelection.js
@@ -22,7 +22,7 @@ export default function useCardSelection({
   const { selectRangeByBox } = useMasonryBoxSelection(gridRef);
 
   const handleVideoSelect = useCallback(
-    (videoId, isCtrlClick, isShiftClick, isDoubleClick) => {
+    (videoId, isCtrlClick, isShiftClick, isDoubleClick, pointer) => {
       const video = getById?.(videoId);
 
       if (isDoubleClick && video) {
@@ -36,7 +36,7 @@ export default function useCardSelection({
           return;
         }
         // bounding-box range; additive when ctrl/meta held
-        selectRangeByBox(selection, selection.anchorId, videoId, isCtrlClick);
+        selectRangeByBox(selection, selection.anchorId, videoId, isCtrlClick, pointer);
         return;
       }
 

--- a/src/hooks/selection/useCardSelection.test.js
+++ b/src/hooks/selection/useCardSelection.test.js
@@ -61,7 +61,7 @@ describe('useCardSelection', () => {
   test('double-click triggers fullscreen when video exists', () => {
     const { result } = render();
     act(() => {
-      result.current.handleVideoSelect('vid1', false, false, true);
+      result.current.handleVideoSelect('vid1', false, false, true, { clientX: 10, clientY: 10 });
     });
     expect(openFullScreen).toHaveBeenCalledWith({ id: 'vid1' }, new Set());
   });
@@ -69,10 +69,10 @@ describe('useCardSelection', () => {
   test('ctrl-click toggles selection; plain click selects only', () => {
     const { result } = render();
 
-    act(() => result.current.handleVideoSelect('a', true, false, false));
+    act(() => result.current.handleVideoSelect('a', true, false, false, { clientX: 0, clientY: 0 }));
     expect(selection.toggle).toHaveBeenCalledWith('a');
 
-    act(() => result.current.handleVideoSelect('b', false, false, false));
+    act(() => result.current.handleVideoSelect('b', false, false, false, { clientX: 0, clientY: 0 }));
     expect(selection.selectOnly).toHaveBeenCalledWith('b');
   });
 
@@ -80,7 +80,7 @@ describe('useCardSelection', () => {
     const { result } = render();
     selection.anchorId = null;
 
-    act(() => result.current.handleVideoSelect('x', false, true, false));
+    act(() => result.current.handleVideoSelect('x', false, true, false, { clientX: 0, clientY: 0 }));
     expect(selection.selectOnly).toHaveBeenCalledWith('x');
   });
 
@@ -126,7 +126,7 @@ describe('useCardSelection', () => {
     selection.anchorId = 'a';
 
     act(() => {
-      result.current.handleVideoSelect('b', /*ctrl*/ false, /*shift*/ true, /*dbl*/ false);
+      result.current.handleVideoSelect('b', /*ctrl*/ false, /*shift*/ true, /*dbl*/ false, { clientX: 150, clientY: 30 });
     });
 
     // setSelected was called with a Set containing a & b (order not guaranteed)

--- a/src/hooks/selection/useMasonryBoxSelection.js
+++ b/src/hooks/selection/useMasonryBoxSelection.js
@@ -1,11 +1,62 @@
 import { useCallback } from 'react';
 
+const MIN_PARTIAL_OVERLAP_RATIO = 0.2;
+
+function clampPointer(pointer, fallbackRect) {
+  if (!pointer ||
+      typeof pointer.clientX !== 'number' ||
+      Number.isNaN(pointer.clientX) ||
+      typeof pointer.clientY !== 'number' ||
+      Number.isNaN(pointer.clientY)) {
+    const centerX = (fallbackRect.left + fallbackRect.right) / 2;
+    const centerY = (fallbackRect.top + fallbackRect.bottom) / 2;
+    return { x: centerX, y: centerY };
+  }
+
+  return { x: pointer.clientX, y: pointer.clientY };
+}
+
+function overlapsMeaningfully(rect, box, pointer) {
+  const overlapLeft = Math.max(box.left, rect.left);
+  const overlapRight = Math.min(box.right, rect.right);
+  const overlapTop = Math.max(box.top, rect.top);
+  const overlapBottom = Math.min(box.bottom, rect.bottom);
+
+  const overlapWidth = overlapRight - overlapLeft;
+  const overlapHeight = overlapBottom - overlapTop;
+
+  if (overlapWidth <= 0 || overlapHeight <= 0) {
+    return false;
+  }
+
+  const overlapArea = overlapWidth * overlapHeight;
+  const rectWidth = rect.width ?? rect.right - rect.left;
+  const rectHeight = rect.height ?? rect.bottom - rect.top;
+  const rectArea = rectWidth * rectHeight;
+
+  const coverage = rectArea > 0 ? overlapArea / rectArea : 0;
+
+  const pointerInside = pointer &&
+    pointer.x >= rect.left &&
+    pointer.x <= rect.right &&
+    pointer.y >= rect.top &&
+    pointer.y <= rect.bottom;
+
+  const boxInsideRect =
+    box.left >= rect.left &&
+    box.right <= rect.right &&
+    box.top >= rect.top &&
+    box.bottom <= rect.bottom;
+
+  return coverage >= MIN_PARTIAL_OVERLAP_RATIO || pointerInside || boxInsideRect;
+}
+
 /**
  * Given a masonry gridRef, provides helpers to compute/select a bounding-box range.
  * Assumes each card root has: class="video-item" and data-video-id={id}
  */
 export default function useMasonryBoxSelection(gridRef) {
-  const getBoxSelectionIds = useCallback((anchorId, endId) => {
+  const getBoxSelectionIds = useCallback((anchorId, endId, pointer) => {
     const grid = gridRef?.current;
     if (!grid || !anchorId || !endId) return new Set();
 
@@ -17,29 +68,38 @@ export default function useMasonryBoxSelection(gridRef) {
       rect: el.getBoundingClientRect()
     }));
 
-    const a = rects.find(r => r.id === anchorId)?.rect;
-    const b = rects.find(r => r.id === endId)?.rect;
-    if (!a || !b) return new Set();
+    const anchorRect = rects.find(r => r.id === anchorId)?.rect;
+    const endRect = rects.find(r => r.id === endId)?.rect;
+    if (!anchorRect || !endRect) return new Set();
 
-    const minX = Math.min(a.left, b.left);
-    const maxX = Math.max(a.right, b.right);
-    const minY = Math.min(a.top, b.top);
-    const maxY = Math.max(a.bottom, b.bottom);
+    const pointerPos = clampPointer(pointer, endRect);
+
+    const endCenterX = (endRect.left + endRect.right) / 2;
+    const endCenterY = (endRect.top + endRect.bottom) / 2;
+
+    const endEdgeX = pointerPos.x >= endCenterX ? endRect.right : endRect.left;
+    const endEdgeY = pointerPos.y >= endCenterY ? endRect.bottom : endRect.top;
+
+    const box = {
+      left: Math.min(anchorRect.left, anchorRect.right, endEdgeX, pointerPos.x),
+      right: Math.max(anchorRect.left, anchorRect.right, endEdgeX, pointerPos.x),
+      top: Math.min(anchorRect.top, anchorRect.bottom, endEdgeY, pointerPos.y),
+      bottom: Math.max(anchorRect.top, anchorRect.bottom, endEdgeY, pointerPos.y)
+    };
 
     const ids = rects
-      .filter(r =>
-        r.rect.left < maxX &&
-        r.rect.right > minX &&
-        r.rect.top < maxY &&
-        r.rect.bottom > minY
-      )
+      .filter(r => overlapsMeaningfully(r.rect, box, pointerPos))
       .map(r => r.id);
 
-    return new Set(ids);
+    const idSet = new Set(ids);
+    if (rects.some(r => r.id === anchorId)) idSet.add(anchorId);
+    if (rects.some(r => r.id === endId)) idSet.add(endId);
+
+    return idSet;
   }, [gridRef]);
 
-  const selectRangeByBox = useCallback((selection, anchorId, endId, additive = false) => {
-    const boxIds = getBoxSelectionIds(anchorId, endId);
+  const selectRangeByBox = useCallback((selection, anchorId, endId, additive = false, pointer) => {
+    const boxIds = getBoxSelectionIds(anchorId, endId, pointer);
     if (!boxIds.size) return;
 
     if (additive) {

--- a/src/hooks/selection/useMasonryBoxSelection.test.js
+++ b/src/hooks/selection/useMasonryBoxSelection.test.js
@@ -53,6 +53,26 @@ describe('useMasonryBoxSelection', () => {
     expect(arr).toEqual(['a', 'b', 'd', 'e']);
   });
 
+  test('getBoxSelectionIds narrows selection using pointer location', () => {
+    const { result } = renderHook(() => useMasonryBoxSelection(gridRef));
+    const { getBoxSelectionIds } = result.current;
+
+    // Pointer is inside the top-left corner of card "e" – expect to keep anchor and end only
+    const ids = getBoxSelectionIds('a', 'e', { clientX: 120, clientY: 75 });
+    const arr = Array.from(ids).sort();
+    expect(arr).toEqual(['a', 'e']);
+  });
+
+  test('getBoxSelectionIds keeps clicked card even if overlap is tiny', () => {
+    const { result } = renderHook(() => useMasonryBoxSelection(gridRef));
+    const { getBoxSelectionIds } = result.current;
+
+    // Simulate clicking the extreme top-left of card "e" – overlap with the box is minimal
+    const ids = getBoxSelectionIds('a', 'e', { clientX: 112, clientY: 72 });
+    expect(ids.has('e')).toBe(true);
+    expect(ids.has('a')).toBe(true);
+  });
+
   test('getBoxSelectionIds returns empty Set if anchor or end not found', () => {
     const { result } = renderHook(() => useMasonryBoxSelection(gridRef));
     const { getBoxSelectionIds } = result.current;
@@ -74,12 +94,12 @@ describe('useMasonryBoxSelection', () => {
     };
 
     // replace
-    selectRangeByBox(selection, 'a', 'e', /*additive*/ false);
+    selectRangeByBox(selection, 'a', 'e', /*additive*/ false, { clientX: 180, clientY: 120 });
     expect(current instanceof Set).toBe(true);
     expect(Array.from(current).sort()).toEqual(['a', 'b', 'd', 'e']);
 
     // additive (merge in anchor=end of a smaller box)
-    selectRangeByBox(selection, 'b', 'b', /*additive*/ true);
+    selectRangeByBox(selection, 'b', 'b', /*additive*/ true, { clientX: 150, clientY: 40 });
     expect(Array.from(current).sort()).toEqual(['a', 'b', 'd', 'e']); // unchanged; 'b' already present
   });
 });


### PR DESCRIPTION
## Summary
- forward pointer coordinates from video card clicks so range selection can use them
- update masonry box selection heuristics to use the cursor position and overlap thresholds
- expand selection tests to cover pointer-aware behaviour and ensure clicked cards stay in range

## Testing
- npx vitest run src/hooks/selection/useMasonryBoxSelection.test.js src/hooks/selection/useCardSelection.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911d844b488832cbb87f5a4fcedef52)