### PR TITLE
Add portable data directory selection and management

### DIFF
--- a/main/data-location-manager.js
+++ b/main/data-location-manager.js
@@ -1,0 +1,530 @@
+const fs = require("fs");
+const fsPromises = fs.promises;
+const path = require("path");
+const os = require("os");
+
+const DEFAULT_CONFIG = {
+  preferredDataDir: null,
+  migrationRequested: false,
+  pendingMigration: null,
+  lastKnownUserDataDir: null,
+  version: 1,
+};
+
+function normalizePath(value) {
+  if (typeof value !== "string" || !value.trim()) {
+    return null;
+  }
+  return path.resolve(value.trim());
+}
+
+function unique(array) {
+  return Array.from(new Set(array.filter(Boolean)));
+}
+
+class DataLocationManager {
+  constructor({ app, dialog }) {
+    this.app = app;
+    this.dialog = dialog;
+    this.config = { ...DEFAULT_CONFIG };
+    this.configPath = null;
+    this.defaultPath = null;
+    this.commandLinePath = null;
+    this.effectivePath = null;
+    this.source = "default";
+    this.portablePresetPath = null;
+  }
+
+  bootstrap(argv = []) {
+    this.defaultPath = this.app.getPath("userData");
+    this.commandLinePath = this.extractCommandLineOverride(argv);
+    this.config = this.loadConfig();
+
+    const preferred = normalizePath(this.config.preferredDataDir);
+    const target = this.commandLinePath || preferred || this.defaultPath;
+    const resolvedTarget = normalizePath(target) || this.defaultPath;
+    this.effectivePath = resolvedTarget;
+
+    if (this.commandLinePath) {
+      this.source = "commandLine";
+    } else if (preferred) {
+      this.source = "config";
+    } else {
+      this.source = "default";
+    }
+
+    if (resolvedTarget !== this.defaultPath) {
+      this.app.setPath("userData", resolvedTarget);
+    }
+
+    this.portablePresetPath = path.join(this.resolveAppFolder(), "VideoSwarmData");
+
+    return {
+      effectivePath: this.effectivePath,
+      source: this.source,
+    };
+  }
+
+  extractCommandLineOverride(argv = []) {
+    if (!Array.isArray(argv)) {
+      return null;
+    }
+
+    const inline = argv.find((arg) =>
+      typeof arg === "string" && arg.startsWith("--user-data-dir=")
+    );
+    if (inline) {
+      const value = inline.slice("--user-data-dir=".length);
+      return normalizePath(value);
+    }
+
+    const index = argv.findIndex((arg) => arg === "--user-data-dir");
+    if (index >= 0 && typeof argv[index + 1] === "string") {
+      return normalizePath(argv[index + 1]);
+    }
+
+    return null;
+  }
+
+  getBootstrapCandidates() {
+    const candidates = [];
+    const appFolder = this.resolveAppFolder();
+    candidates.push(path.join(appFolder, "videoswarm-bootstrap.json"));
+
+    const homeFallback = path.join(os.homedir(), ".videoswarm");
+    candidates.push(path.join(homeFallback, "videoswarm-bootstrap.json"));
+
+    return unique(candidates);
+  }
+
+  resolveAppFolder() {
+    try {
+      if (this.app.isPackaged) {
+        return path.dirname(process.execPath);
+      }
+      return path.resolve(this.app.getAppPath());
+    } catch (error) {
+      console.warn("[data-location] Failed to resolve app folder", error);
+      return path.dirname(process.execPath);
+    }
+  }
+
+  loadConfig() {
+    const candidates = this.getBootstrapCandidates();
+    for (const candidate of candidates) {
+      try {
+        if (!fs.existsSync(candidate)) {
+          continue;
+        }
+        const raw = fs.readFileSync(candidate, "utf8");
+        const parsed = JSON.parse(raw);
+        this.configPath = candidate;
+        return { ...DEFAULT_CONFIG, ...parsed };
+      } catch (error) {
+        console.warn("[data-location] Failed to read bootstrap config", error);
+      }
+    }
+
+    this.configPath = candidates[0];
+    return { ...DEFAULT_CONFIG };
+  }
+
+  async saveConfig() {
+    const payload = JSON.stringify({ ...this.config, version: 1 }, null, 2);
+    const tried = new Set();
+    const candidates = unique([this.configPath, ...this.getBootstrapCandidates()]);
+
+    for (const candidate of candidates) {
+      if (!candidate || tried.has(candidate)) {
+        continue;
+      }
+      tried.add(candidate);
+      try {
+        await fsPromises.mkdir(path.dirname(candidate), { recursive: true });
+        await fsPromises.writeFile(candidate, payload, "utf8");
+        this.configPath = candidate;
+        return candidate;
+      } catch (error) {
+        console.warn("[data-location] Failed to save bootstrap config", {
+          candidate,
+          error: error?.message,
+        });
+      }
+    }
+
+    throw new Error("Unable to write bootstrap configuration");
+  }
+
+  async saveConfigSafe() {
+    try {
+      await this.saveConfig();
+    } catch (error) {
+      console.error("[data-location] Unable to persist bootstrap config", error);
+    }
+  }
+
+  async ensureDirectoryWritable(targetPath) {
+    const normalized = normalizePath(targetPath);
+    if (!normalized) {
+      return { ok: false, reason: "EMPTY" };
+    }
+
+    try {
+      await fsPromises.mkdir(normalized, { recursive: true });
+    } catch (error) {
+      return { ok: false, reason: "CREATE_FAILED", error };
+    }
+
+    try {
+      const probe = path.join(
+        normalized,
+        `.videoswarm-write-test-${Date.now()}-${Math.random()
+          .toString(16)
+          .slice(2)}`
+      );
+      await fsPromises.writeFile(probe, "ok", "utf8");
+      await fsPromises.unlink(probe).catch(() => {});
+      return { ok: true };
+    } catch (error) {
+      return { ok: false, reason: "WRITE_FAILED", error };
+    }
+  }
+
+  async ensureReady() {
+    if (this.commandLinePath) {
+      await this.ensureReadyForCommandLine();
+      return;
+    }
+
+    await this.ensureReadyForConfig();
+  }
+
+  async ensureReadyForCommandLine() {
+    const target = this.commandLinePath;
+    if (!target) {
+      return;
+    }
+
+    while (true) {
+      const check = await this.ensureDirectoryWritable(target);
+      if (check.ok) {
+        this.effectivePath = target;
+        this.config.lastKnownUserDataDir = target;
+        this.source = "commandLine";
+        await this.saveConfigSafe();
+        return;
+      }
+
+      const detail = check.error?.message || "";
+      const { response } = await this.dialog.showMessageBox({
+        type: "error",
+        buttons: ["Retry", "Quit"],
+        defaultId: 0,
+        cancelId: 1,
+        title: "VideoSwarm",
+        message:
+          "VideoSwarm cannot access the data folder specified by '--user-data-dir'.",
+        detail: `${target}\n\n${detail}`.trim(),
+        noLink: true,
+      });
+
+      if (response !== 0) {
+        this.app.exit(1);
+        return;
+      }
+    }
+  }
+
+  async ensureReadyForConfig() {
+    while (true) {
+      const target = this.app.getPath("userData");
+      const check = await this.ensureDirectoryWritable(target);
+      if (check.ok) {
+        this.effectivePath = target;
+        break;
+      }
+
+      const detail = check.error?.message || "";
+      const { response } = await this.dialog.showMessageBox({
+        type: "error",
+        buttons: [
+          "Choose another folder…",
+          "Use default system location",
+          "Quit",
+        ],
+        defaultId: 0,
+        cancelId: 2,
+        title: "VideoSwarm",
+        message: "VideoSwarm cannot access the configured data folder.",
+        detail: `${target}\n\n${detail}`.trim(),
+        noLink: true,
+      });
+
+      if (response === 2 || response === -1) {
+        this.app.exit(1);
+        return;
+      }
+
+      if (response === 1) {
+        this.config.preferredDataDir = null;
+        this.config.migrationRequested = false;
+        this.config.pendingMigration = null;
+        this.effectivePath = this.defaultPath;
+        this.app.setPath("userData", this.defaultPath);
+        this.source = "default";
+        await this.saveConfigSafe();
+        continue;
+      }
+
+      const selection = await this.dialog.showOpenDialog({
+        title: "Select VideoSwarm data folder",
+        properties: ["openDirectory", "createDirectory"],
+      });
+
+      if (selection.canceled || !selection.filePaths?.length) {
+        continue;
+      }
+
+      const chosen = normalizePath(selection.filePaths[0]);
+      if (!chosen) {
+        continue;
+      }
+
+      this.config.preferredDataDir = chosen;
+      this.config.migrationRequested = false;
+      this.config.pendingMigration = null;
+      this.effectivePath = chosen;
+      this.app.setPath("userData", chosen);
+      this.source = "config";
+      await this.saveConfigSafe();
+    }
+
+    if (this.config?.pendingMigration?.mode === "move") {
+      await this.performPendingMigration();
+    } else {
+      this.config.migrationRequested = false;
+      this.config.pendingMigration = null;
+      await this.saveConfigSafe();
+    }
+
+    this.config.lastKnownUserDataDir = this.effectivePath;
+    await this.saveConfigSafe();
+  }
+
+  async performPendingMigration() {
+    const pending = this.config.pendingMigration;
+    if (!pending || pending.mode !== "move") {
+      this.config.migrationRequested = false;
+      this.config.pendingMigration = null;
+      await this.saveConfigSafe();
+      return;
+    }
+
+    const source = normalizePath(pending.from);
+    const destination = normalizePath(pending.to);
+
+    if (!source || !destination || source === destination) {
+      this.config.migrationRequested = false;
+      this.config.pendingMigration = null;
+      const fallbackTarget = destination || this.defaultPath;
+      this.config.lastKnownUserDataDir = fallbackTarget;
+      this.effectivePath = fallbackTarget;
+      this.source =
+        fallbackTarget === this.defaultPath ? "default" : "config";
+      await this.saveConfigSafe();
+      return;
+    }
+
+    while (true) {
+      try {
+        const sourceExists = await fsPromises
+          .stat(source)
+          .then(() => true)
+          .catch(() => false);
+
+        if (!sourceExists) {
+          this.config.migrationRequested = false;
+          this.config.pendingMigration = null;
+          this.config.lastKnownUserDataDir = destination;
+          this.effectivePath = destination;
+          this.source = destination === this.defaultPath ? "default" : "config";
+          await this.saveConfigSafe();
+          return;
+        }
+
+        await fsPromises.mkdir(destination, { recursive: true });
+        await fsPromises.cp(source, destination, {
+          recursive: true,
+          force: true,
+        });
+        await fsPromises.rm(source, { recursive: true, force: true });
+
+        this.config.migrationRequested = false;
+        this.config.pendingMigration = null;
+        this.config.lastKnownUserDataDir = destination;
+        this.effectivePath = destination;
+        this.source = destination === this.defaultPath ? "default" : "config";
+        this.app.setPath("userData", destination);
+        await this.saveConfigSafe();
+        return;
+      } catch (error) {
+        const { response } = await this.dialog.showMessageBox({
+          type: "warning",
+          buttons: ["Retry", "Revert to old folder", "Continue anyway"],
+          defaultId: 0,
+          cancelId: 2,
+          title: "VideoSwarm",
+          message: "Moving VideoSwarm data to the new folder failed.",
+          detail: error?.message || "",
+          noLink: true,
+        });
+
+        if (response === 0) {
+          continue;
+        }
+
+        if (response === 1) {
+          const revertPath = source;
+          this.config.preferredDataDir =
+            revertPath && revertPath === this.defaultPath ? null : revertPath;
+          this.config.migrationRequested = false;
+          this.config.pendingMigration = null;
+          this.effectivePath = revertPath || this.defaultPath;
+          this.config.lastKnownUserDataDir = this.effectivePath;
+          this.source =
+            this.effectivePath === this.defaultPath ? "default" : "config";
+          this.app.setPath("userData", this.effectivePath);
+          await this.saveConfigSafe();
+          return;
+        }
+
+        this.config.migrationRequested = false;
+        this.config.pendingMigration = null;
+        this.config.lastKnownUserDataDir = destination;
+        this.effectivePath = destination;
+        this.source = destination === this.defaultPath ? "default" : "config";
+        await this.saveConfigSafe();
+        return;
+      }
+    }
+  }
+
+  getRendererState() {
+    const preferredPath = normalizePath(this.config.preferredDataDir);
+    const effectivePath = this.app.getPath("userData");
+    return {
+      defaultPath: this.defaultPath,
+      effectivePath,
+      preferredPath,
+      isUsingDefault: !preferredPath,
+      isCommandLineOverride: !!this.commandLinePath,
+      commandLinePath: this.commandLinePath,
+      portablePresetPath: this.portablePresetPath,
+      migrationRequested: !!this.config.migrationRequested,
+      source: this.source,
+    };
+  }
+
+  async browseForDirectory(browserWindow) {
+    const result = await this.dialog.showOpenDialog(browserWindow || null, {
+      title: "Select VideoSwarm data folder",
+      properties: ["openDirectory", "createDirectory"],
+    });
+
+    if (result.canceled || !result.filePaths?.length) {
+      return null;
+    }
+
+    return normalizePath(result.filePaths[0]);
+  }
+
+  async applySelection(payload = {}, browserWindow) {
+    if (this.commandLinePath) {
+      return { status: "overridden" };
+    }
+
+    const useDefault = !!payload.useDefault;
+    const requestedPath = normalizePath(payload.customPath);
+    const targetPath = useDefault ? this.defaultPath : requestedPath;
+
+    if (!useDefault && !requestedPath) {
+      return { status: "invalid", reason: "missing-custom-path" };
+    }
+
+    const current = this.app.getPath("userData");
+    if (normalizePath(current) === normalizePath(targetPath)) {
+      return { status: "unchanged" };
+    }
+
+    const { response } = await this.dialog.showMessageBox(browserWindow || null, {
+      type: "question",
+      buttons: [
+        "Move & Restart",
+        "Use New Folder (Fresh Data) & Restart",
+        "Cancel",
+      ],
+      defaultId: 0,
+      cancelId: 2,
+      title: "VideoSwarm",
+      message:
+        "VideoSwarm needs to restart to use the new data folder. Move your existing settings, profiles, thumbnails, and caches to the new location?",
+      noLink: true,
+    });
+
+    if (response === 2 || response === -1) {
+      return { status: "cancelled" };
+    }
+
+    const shouldMove = response === 0;
+    const check = await this.ensureDirectoryWritable(targetPath);
+    if (!check.ok) {
+      await this.dialog.showMessageBox(browserWindow || null, {
+        type: "error",
+        buttons: ["OK"],
+        defaultId: 0,
+        cancelId: 0,
+        title: "VideoSwarm",
+        message: "VideoSwarm cannot write to the selected data folder.",
+        detail: check.error?.message || "",
+        noLink: true,
+      });
+      return { status: "invalid", reason: "unwritable" };
+    }
+
+    const normalizedTarget = normalizePath(targetPath);
+    const normalizedCurrent = normalizePath(current);
+
+    this.config.preferredDataDir =
+      normalizedTarget && normalizedTarget === this.defaultPath
+        ? null
+        : normalizedTarget;
+    this.config.lastKnownUserDataDir = normalizedTarget;
+    this.source = normalizedTarget === this.defaultPath ? "default" : "config";
+
+    if (shouldMove) {
+      this.config.migrationRequested = true;
+      this.config.pendingMigration = {
+        from: normalizedCurrent,
+        to: normalizedTarget,
+        mode: "move",
+      };
+    } else {
+      this.config.migrationRequested = false;
+      this.config.pendingMigration = null;
+    }
+
+    await this.saveConfigSafe();
+
+    setImmediate(() => {
+      try {
+        this.app.relaunch();
+      } finally {
+        this.app.exit(0);
+      }
+    });
+
+    return { status: "relaunching" };
+  }
+}
+
+module.exports = { DataLocationManager };

--- a/main/data-location-manager.js
+++ b/main/data-location-manager.js
@@ -459,8 +459,8 @@ class DataLocationManager {
     const { response } = await this.dialog.showMessageBox(browserWindow || null, {
       type: "question",
       buttons: [
-        "Move & Restart",
-        "Use New Folder (Fresh Data) & Restart",
+        "Move && Restart",
+        "Use New Folder (Fresh Data) && Restart",
         "Cancel",
       ],
       defaultId: 0,

--- a/preload.js
+++ b/preload.js
@@ -11,6 +11,21 @@ contextBridge.exposeInMainWorld("electronAPI", {
 
   openDonationPage: () => ipcRenderer.invoke("support:open-donation"),
 
+  onOpenDataLocation: (callback) => {
+    if (typeof callback !== "function") {
+      return () => {};
+    }
+    const handler = () => callback();
+    ipcRenderer.on("ui:open-data-location", handler);
+    return () => ipcRenderer.removeListener("ui:open-data-location", handler);
+  },
+
+  dataLocation: {
+    getState: () => ipcRenderer.invoke("data-location:get-state"),
+    browse: () => ipcRenderer.invoke("data-location:browse"),
+    applySelection: (payload) => ipcRenderer.invoke("data-location:apply", payload),
+  },
+
   // File manager integration
   showItemInFolder: async (filePath) => {
     return await ipcRenderer.invoke("show-item-in-folder", filePath);

--- a/src/App.css
+++ b/src/App.css
@@ -342,6 +342,222 @@ body {
   outline: none;
 }
 
+.data-location-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 2050;
+  padding: 1.5rem;
+}
+
+.data-location-dialog {
+  width: min(640px, 100%);
+  background: var(--color-surface);
+  color: var(--color-text);
+  border-radius: 18px;
+  border: 1px solid var(--color-border);
+  box-shadow: 0 24px 48px rgba(0, 0, 0, 0.4);
+  display: flex;
+  flex-direction: column;
+  max-height: calc(100vh - 3rem);
+}
+
+.data-location-dialog__header {
+  padding: 1.25rem 1.5rem 1rem;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.data-location-dialog__header h2 {
+  margin: 0;
+  font-size: 1.45rem;
+}
+
+.data-location-dialog__body {
+  padding: 1.25rem 1.5rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  overflow-y: auto;
+}
+
+.data-location-banner {
+  border-radius: 12px;
+  padding: 0.75rem 1rem;
+  font-size: 0.95rem;
+  line-height: 1.45;
+}
+
+.data-location-banner--warning {
+  background: rgba(255, 193, 7, 0.12);
+  border: 1px solid rgba(255, 193, 7, 0.35);
+  color: #ffd86b;
+}
+
+.data-location-current {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  font-size: 0.95rem;
+}
+
+.data-location-current__label {
+  opacity: 0.8;
+}
+
+.data-location-current__value {
+  font-family: var(--font-mono, "Fira Code", "SFMono-Regular", Menlo, monospace);
+  word-break: break-all;
+  font-size: 0.9rem;
+}
+
+.data-location-options {
+  border: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  min-inline-size: 0;
+}
+
+.data-location-option {
+  display: flex;
+  gap: 1rem;
+  align-items: flex-start;
+  background: rgba(255, 255, 255, 0.02);
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  border: 1px solid transparent;
+  transition: border-color 0.15s ease, background 0.15s ease;
+}
+
+.data-location-option input[type="radio"] {
+  margin-top: 0.35rem;
+}
+
+.data-location-option__content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.data-location-option__title {
+  font-weight: 600;
+  font-size: 1.05rem;
+}
+
+.data-location-option__description {
+  font-size: 0.95rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.data-location-option--custom {
+  background: rgba(132, 94, 247, 0.08);
+  border-color: rgba(132, 94, 247, 0.32);
+}
+
+.data-location-input {
+  width: 100%;
+  padding: 0.55rem 0.75rem;
+  border-radius: 8px;
+  border: 1px solid var(--color-border);
+  background: rgba(255, 255, 255, 0.03);
+  color: var(--color-text);
+  font-family: var(--font-mono, "Fira Code", "SFMono-Regular", Menlo, monospace);
+  font-size: 0.9rem;
+}
+
+.data-location-input::placeholder {
+  color: rgba(255, 255, 255, 0.45);
+}
+
+.data-location-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.data-location-button {
+  border-radius: 8px;
+  border: 1px solid var(--color-border);
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--color-text);
+  padding: 0.45rem 0.9rem;
+  cursor: pointer;
+  transition: background 0.15s ease, border-color 0.15s ease, opacity 0.15s ease;
+  font-size: 0.9rem;
+}
+
+.data-location-button:hover:not(:disabled),
+.data-location-button:focus-visible:not(:disabled) {
+  background: rgba(255, 255, 255, 0.08);
+  border-color: rgba(255, 255, 255, 0.25);
+  outline: none;
+}
+
+.data-location-button:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.data-location-hint {
+  margin: 0;
+  font-size: 0.85rem;
+  opacity: 0.7;
+}
+
+.data-location-status {
+  border-radius: 10px;
+  padding: 0.75rem 1rem;
+  font-size: 0.93rem;
+  line-height: 1.45;
+}
+
+.data-location-status--error {
+  background: rgba(239, 83, 80, 0.15);
+  border: 1px solid rgba(239, 83, 80, 0.4);
+  color: #ff8a80;
+}
+
+.data-location-status--warning {
+  background: rgba(255, 193, 7, 0.15);
+  border: 1px solid rgba(255, 193, 7, 0.4);
+  color: #ffd86b;
+}
+
+.data-location-status--info {
+  background: rgba(41, 182, 246, 0.16);
+  border: 1px solid rgba(41, 182, 246, 0.35);
+  color: #82cfff;
+}
+
+.data-location-dialog__footer {
+  padding: 1rem 1.5rem 1.5rem;
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+.data-location-button--primary {
+  background: rgba(132, 94, 247, 0.8);
+  border-color: rgba(132, 94, 247, 0.9);
+}
+
+.data-location-button--primary:hover:not(:disabled),
+.data-location-button--primary:focus-visible:not(:disabled) {
+  background: rgba(132, 94, 247, 1);
+  border-color: rgba(132, 94, 247, 1);
+}
+
+.data-location-button--secondary {
+  background: transparent;
+}
+
 .profile-prompt-backdrop {
   position: fixed;
   inset: 0;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -15,6 +15,7 @@ import HeaderBar from "./components/HeaderBar";
 import FiltersPopover from "./components/FiltersPopover";
 import DebugSummary from "./components/DebugSummary";
 import AboutDialog from "./components/AboutDialog";
+import DataLocationDialog from "./components/DataLocationDialog";
 import ProfilePromptDialog from "./components/ProfilePromptDialog";
 
 import { useFullScreenModal } from "./hooks/useFullScreenModal";
@@ -148,6 +149,7 @@ function App() {
   const [groupByFolders, setGroupByFolders] = useState(true);
   const [randomSeed, setRandomSeed] = useState(null);
   const [isAboutOpen, setAboutOpen] = useState(false);
+  const [isDataLocationOpen, setDataLocationOpen] = useState(false);
   const [profilePromptRequest, setProfilePromptRequest] = useState(null);
   const [profilePromptValue, setProfilePromptValue] = useState("");
 
@@ -186,6 +188,17 @@ function App() {
   const respondToProfilePrompt = useCallback((requestId, value) => {
     const profilesApi = window.electronAPI?.profiles;
     profilesApi?.respondToPrompt?.(requestId, value);
+  }, []);
+
+  useEffect(() => {
+    const unsubscribe = window.electronAPI?.onOpenDataLocation?.(() => {
+      setDataLocationOpen(true);
+    });
+    return () => {
+      if (typeof unsubscribe === "function") {
+        unsubscribe();
+      }
+    };
   }, []);
 
   useEffect(() => {
@@ -1394,6 +1407,10 @@ function App() {
           )}
 
           <AboutDialog open={isAboutOpen} onClose={() => setAboutOpen(false)} />
+          <DataLocationDialog
+            open={isDataLocationOpen}
+            onClose={() => setDataLocationOpen(false)}
+          />
 
           {profilePromptRequest ? (
             <ProfilePromptDialog

--- a/src/components/DataLocationDialog.jsx
+++ b/src/components/DataLocationDialog.jsx
@@ -23,6 +23,8 @@ export default function DataLocationDialog({ open, onClose }) {
   const overrideActive = !!state?.isCommandLineOverride;
   const portablePreset = state?.portablePresetPath || "";
   const effectivePath = state?.effectivePath || "";
+  const defaultPath = state?.defaultPath || "";
+  const effectivePathUnavailable = !!state?.effectivePathUnavailable;
 
   useEffect(() => {
     if (!open) return undefined;
@@ -190,6 +192,9 @@ export default function DataLocationDialog({ open, onClose }) {
 
   if (!open) return null;
 
+  const shouldShowDefaultPathHint =
+    !!defaultPath && state && !state.isUsingDefault;
+
   return (
     <div
       className="data-location-backdrop"
@@ -216,10 +221,27 @@ export default function DataLocationDialog({ open, onClose }) {
               Data location is controlled by the '--user-data-dir' command-line option.
             </div>
           ) : null}
+
           <div className="data-location-current">
             <span className="data-location-current__label">Current data folder:</span>
             <code className="data-location-current__value">{effectivePath}</code>
+            <p className="data-location-current__hint">
+              Includes profiles, thumbnails, metadata database, cache, and logs.
+            </p>
+            {effectivePathUnavailable ? (
+              <div className="data-location-current__warning">
+                <span
+                  className="data-location-current__warning-icon"
+                  aria-hidden="true"
+                />
+                <span className="data-location-current__warning-text">
+                  VideoSwarm cannot currently access this folder. Check that the drive
+                  or network location is available.
+                </span>
+              </div>
+            ) : null}
           </div>
+
           <fieldset
             className="data-location-options"
             disabled={overrideActive || busy || !state}
@@ -240,11 +262,23 @@ export default function DataLocationDialog({ open, onClose }) {
                   Use default system location
                 </div>
                 <div className="data-location-option__description">
-                  Stores data in your OS user profile (AppData/Roaming on Windows,
-                  ~/.config on Linux).
+                  {shouldShowDefaultPathHint ? (
+                    <>
+                      Stores data in:
+                      <code className="data-location-option__path">{defaultPath}</code>
+                    </>
+                  ) : (
+                    "Stores data in your OS user profile."
+                  )}
                 </div>
               </div>
             </label>
+
+            <div
+              className="data-location-options__divider"
+              role="separator"
+              aria-hidden="true"
+            />
 
             <label className="data-location-option data-location-option--custom">
               <input
@@ -280,18 +314,20 @@ export default function DataLocationDialog({ open, onClose }) {
                       type="button"
                       className="data-location-button"
                       onClick={handlePortable}
-                      disabled={
-                        overrideActive || busy || !portablePreset
-                      }
+                      disabled={overrideActive || busy || !portablePreset}
                     >
                       Set to app folder (portable mode)
                     </button>
                   </div>
-                  <p className="data-location-hint">Takes effect after restart.</p>
                 </div>
               </div>
             </label>
           </fieldset>
+
+          <p className="data-location-hint-global">
+            Changes to the data location take effect after restart.
+          </p>
+
           {statusMessage ? (
             <div
               className={`data-location-status data-location-status--${statusMessage.type}`}

--- a/src/components/DataLocationDialog.jsx
+++ b/src/components/DataLocationDialog.jsx
@@ -1,0 +1,334 @@
+import React, { useEffect, useMemo, useRef, useState } from "react";
+
+function normalize(value) {
+  if (typeof value !== "string") {
+    return "";
+  }
+  return value.trim();
+}
+
+function buildMessage(type, text) {
+  if (!text) return null;
+  return { type, text };
+}
+
+export default function DataLocationDialog({ open, onClose }) {
+  const dialogRef = useRef(null);
+  const [state, setState] = useState(null);
+  const [mode, setMode] = useState("default");
+  const [customPath, setCustomPath] = useState("");
+  const [statusMessage, setStatusMessage] = useState(null);
+  const [busy, setBusy] = useState(false);
+
+  const overrideActive = !!state?.isCommandLineOverride;
+  const portablePreset = state?.portablePresetPath || "";
+  const effectivePath = state?.effectivePath || "";
+
+  useEffect(() => {
+    if (!open) return undefined;
+    const handleKeyDown = (event) => {
+      if (event.key === "Escape") {
+        onClose?.();
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [open, onClose]);
+
+  useEffect(() => {
+    if (!open) return undefined;
+    const previousActiveElement = document.activeElement;
+    const firstFocusable = dialogRef.current?.querySelector(
+      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+    );
+    firstFocusable?.focus?.();
+    return () => {
+      previousActiveElement?.focus?.();
+    };
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) {
+      return undefined;
+    }
+    let alive = true;
+    setBusy(false);
+    setStatusMessage(null);
+    const loadState = async () => {
+      try {
+        const api = window.electronAPI?.dataLocation;
+        const nextState = await api?.getState?.();
+        if (!alive) return;
+        setState(nextState || null);
+        const useDefault = !!nextState?.isUsingDefault;
+        setMode(useDefault ? "default" : "custom");
+        if (useDefault) {
+          setCustomPath("");
+        } else {
+          setCustomPath(nextState?.preferredPath || nextState?.effectivePath || "");
+        }
+      } catch (error) {
+        if (!alive) return;
+        setStatusMessage(
+          buildMessage("error", error?.message || "Unable to load data location state.")
+        );
+      }
+    };
+    loadState();
+    return () => {
+      alive = false;
+    };
+  }, [open]);
+
+  const trimmedCustomPath = useMemo(() => normalize(customPath), [customPath]);
+
+  const hasChanges = useMemo(() => {
+    if (!state) return false;
+    if (mode === "default") {
+      return !state.isUsingDefault;
+    }
+    if (!trimmedCustomPath) {
+      return false;
+    }
+    const currentPreferred = normalize(state.preferredPath);
+    return currentPreferred !== trimmedCustomPath;
+  }, [state, mode, trimmedCustomPath]);
+
+  const handleBrowse = async () => {
+    if (overrideActive || busy) return;
+    try {
+      const api = window.electronAPI?.dataLocation;
+      const result = await api?.browse?.();
+      if (result) {
+        setMode("custom");
+        setCustomPath(result);
+        setStatusMessage(null);
+      }
+    } catch (error) {
+      setStatusMessage(
+        buildMessage("error", error?.message || "Unable to select folder.")
+      );
+    }
+  };
+
+  const handlePortable = () => {
+    if (!portablePreset || overrideActive || busy) return;
+    setMode("custom");
+    setCustomPath(portablePreset);
+    setStatusMessage(null);
+  };
+
+  const handleApply = async () => {
+    if (!state || overrideActive || busy) {
+      return;
+    }
+    if (!hasChanges) {
+      onClose?.();
+      return;
+    }
+    if (mode === "custom" && !trimmedCustomPath) {
+      setStatusMessage(buildMessage("error", "Select a folder for custom data."));
+      return;
+    }
+
+    try {
+      setBusy(true);
+      const api = window.electronAPI?.dataLocation;
+      const result = await api?.applySelection?.({
+        useDefault: mode === "default",
+        customPath: trimmedCustomPath,
+      });
+      switch (result?.status) {
+        case "unchanged":
+          onClose?.();
+          break;
+        case "cancelled":
+          setBusy(false);
+          break;
+        case "invalid":
+          setBusy(false);
+          if (result?.reason === "missing-custom-path") {
+            setStatusMessage(
+              buildMessage("error", "Select a folder before applying the change.")
+            );
+          } else if (result?.reason === "unwritable") {
+            setStatusMessage(
+              buildMessage(
+                "error",
+                "VideoSwarm cannot write to the selected folder. Choose another location."
+              )
+            );
+          } else {
+            setStatusMessage(
+              buildMessage("error", "Unable to use the selected folder.")
+            );
+          }
+          break;
+        case "overridden":
+          setBusy(false);
+          setStatusMessage(
+            buildMessage(
+              "warning",
+              "Data location is controlled by the '--user-data-dir' command-line option."
+            )
+          );
+          break;
+        case "relaunching":
+          setStatusMessage(buildMessage("info", "VideoSwarm is restarting..."));
+          break;
+        default:
+          onClose?.();
+          break;
+      }
+    } catch (error) {
+      setBusy(false);
+      setStatusMessage(
+        buildMessage("error", error?.message || "Failed to apply the new data folder.")
+      );
+    }
+  };
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="data-location-backdrop"
+      role="presentation"
+      onClick={(event) => {
+        if (event.target === event.currentTarget && !busy) {
+          onClose?.();
+        }
+      }}
+    >
+      <div
+        className="data-location-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="data-location-dialog__title"
+        ref={dialogRef}
+      >
+        <header className="data-location-dialog__header">
+          <h2 id="data-location-dialog__title">Data Location</h2>
+        </header>
+        <div className="data-location-dialog__body">
+          {overrideActive ? (
+            <div className="data-location-banner data-location-banner--warning">
+              Data location is controlled by the '--user-data-dir' command-line option.
+            </div>
+          ) : null}
+          <div className="data-location-current">
+            <span className="data-location-current__label">Current data folder:</span>
+            <code className="data-location-current__value">{effectivePath}</code>
+          </div>
+          <fieldset
+            className="data-location-options"
+            disabled={overrideActive || busy || !state}
+          >
+            <label className="data-location-option">
+              <input
+                type="radio"
+                name="data-location-mode"
+                value="default"
+                checked={mode === "default"}
+                onChange={() => {
+                  setMode("default");
+                  setStatusMessage(null);
+                }}
+              />
+              <div className="data-location-option__content">
+                <div className="data-location-option__title">
+                  Use default system location
+                </div>
+                <div className="data-location-option__description">
+                  Stores data in your OS user profile (AppData/Roaming on Windows,
+                  ~/.config on Linux).
+                </div>
+              </div>
+            </label>
+
+            <label className="data-location-option data-location-option--custom">
+              <input
+                type="radio"
+                name="data-location-mode"
+                value="custom"
+                checked={mode === "custom"}
+                onChange={() => {
+                  setMode("custom");
+                  setStatusMessage(null);
+                }}
+              />
+              <div className="data-location-option__content">
+                <div className="data-location-option__title">Use custom folder</div>
+                <div className="data-location-option__description">
+                  <input
+                    type="text"
+                    className="data-location-input"
+                    value={trimmedCustomPath}
+                    readOnly
+                    placeholder="Choose a folder"
+                  />
+                  <div className="data-location-actions">
+                    <button
+                      type="button"
+                      className="data-location-button"
+                      onClick={handleBrowse}
+                      disabled={overrideActive || busy}
+                    >
+                      Browse…
+                    </button>
+                    <button
+                      type="button"
+                      className="data-location-button"
+                      onClick={handlePortable}
+                      disabled={
+                        overrideActive || busy || !portablePreset
+                      }
+                    >
+                      Set to app folder (portable mode)
+                    </button>
+                  </div>
+                  <p className="data-location-hint">Takes effect after restart.</p>
+                </div>
+              </div>
+            </label>
+          </fieldset>
+          {statusMessage ? (
+            <div
+              className={`data-location-status data-location-status--${statusMessage.type}`}
+              role="status"
+            >
+              {statusMessage.text}
+            </div>
+          ) : null}
+        </div>
+        <footer className="data-location-dialog__footer">
+          <button
+            type="button"
+            className="data-location-button data-location-button--secondary"
+            onClick={() => {
+              if (!busy) {
+                onClose?.();
+              }
+            }}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="data-location-button data-location-button--primary"
+            onClick={handleApply}
+            disabled={
+              overrideActive ||
+              busy ||
+              !state ||
+              !hasChanges ||
+              (mode === "custom" && !trimmedCustomPath)
+            }
+          >
+            Apply
+          </button>
+        </footer>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a data location manager that reads bootstrap configuration, validates directories, and performs pending migrations before app startup
- expose a new Options → Data Location modal with portable preset, browse controls, and CLI override messaging in the renderer
- update preload and menu wiring so users can adjust the persistent data folder and trigger restarts when applying changes

Closes #69 