### PR TITLE
Implement linear-order shift-click selection behavior

### DIFF
--- a/docs/shift-click-multi-selection.md
+++ b/docs/shift-click-multi-selection.md
@@ -1,0 +1,85 @@
+# VideoSwarm Shift-Click Multi-Selection Specification
+
+## 1. Overview
+VideoSwarm displays videos in a masonry-style wall where card height varies per item. Because masonry layouts have no reliable row structure, multi-selection behaviors must follow the linear ordering of the underlying dataset. This document describes the user experience, data model, and interaction rules required to deliver shift-click range selection that matches expectations set by desktop operating systems and photo management applications.
+
+## 2. Goals
+- Deliver intuitive multi-selection semantics comparable to Google Photos, Apple Photos, Windows Explorer, and macOS Finder.
+- Base every selection decision on the canonical linear order rather than on-screen positions.
+- Keep selection state stable across viewport resizing, masonry reflows, filtering, and sorting.
+- Provide hooks for visual feedback and accessibility features that communicate the current selection.
+
+## 3. Definitions
+### 3.1 Linear Order
+A stable array containing every video item exactly once, sorted according to the active sort mode (e.g., newest first, alphabetical). Masonry layout calculations must read from but never alter this order.
+
+### 3.2 Selection Anchor
+The linear index of the last item that was selected by a non-toggle interaction (single click or shift-click). It defines the starting point for shift-click ranges.
+
+### 3.3 Toggle Selection
+Any selection change triggered via `Ctrl`/`Cmd` + click. Toggle actions add or remove a single item without affecting the anchor.
+
+## 4. Supported User Interactions
+### 4.1 Single Click
+- Clears existing selection.
+- Selects the clicked item exclusively.
+- Sets the selection anchor to the clicked item's linear index.
+
+### 4.2 Ctrl/Cmd + Click
+- Toggles the clicked item's selected state.
+- Leaves the current selection anchor unchanged.
+
+### 4.3 Shift + Click
+- Computes the contiguous linear range between the selection anchor and the clicked item.
+- Replaces the current selection with that range (unless optional merge behavior is enabled).
+- Updates the anchor to the clicked item's index.
+
+### 4.4 Optional Shift-Hover Preview
+- While the user hovers with the `Shift` modifier held, preview-highlight the range that would be selected if clicked.
+- Preview must use the same linear-order algorithm as shift-click.
+
+## 5. Prohibited Behaviors
+- Do not interpret shift-click as a geometric bounding-box selection.
+- Never rely on the masonry layout's spatial arrangement to infer selection ranges.
+- Avoid behaviors that cause the same shift-click action to yield different results after a reflow.
+
+## 6. Data Requirements
+- Maintain a canonical, ordered array of video metadata that represents the user's chosen sort mode.
+- Each rendered card must receive its immutable linear index.
+- Persist selection state separately from layout-specific data structures.
+- Ensure updates to the masonry layout do not mutate selection state or linear indices.
+
+## 7. Shift-Click Algorithm (Conceptual)
+1. Retrieve `anchorIndex` (if undefined, fall back to `clickedIndex`).
+2. Determine `clickedIndex` from the card's stored linear index.
+3. Compute `startIndex = Math.min(anchorIndex, clickedIndex)` and `endIndex = Math.max(anchorIndex, clickedIndex)`.
+4. Select every item whose linear index is in `[startIndex, endIndex]`; deselect all others unless optional merge rules apply.
+5. Update the selection anchor to `clickedIndex`.
+
+## 8. Optional Extended Behavior
+- When `Ctrl/Cmd + Shift + click` is detected, merge the computed range with the existing selection instead of replacing it.
+- Define deterministic tie-breaking for conflicts when optional merge behaviors intersect with toggled items.
+
+## 9. Visual Feedback Requirements
+- Provide a clear selected-state indicator for all selected cards.
+- Offer an optional lighter preview highlight for range previews.
+- Consider displaying a toast or status indicator when large ranges are selected.
+- Ensure selected and preview states are conveyed via ARIA attributes for screen readers.
+
+## 10. Viewport and Layout Behavior
+- Selection state must persist through masonry reflows, responsive breakpoint changes, and virtualized rendering updates.
+- Changing sort order preserves the current selection set but resets the anchor to `undefined` so that the next shift-click establishes a new reference point.
+
+## 11. Edge Cases
+- If no anchor exists (e.g., first interaction), the clicked item becomes both selected and the anchor.
+- If the anchor item is removed or filtered out, promote the earliest selected item's index to anchor; if none remain, the next single click sets a fresh anchor.
+- Items outside the viewport must remain selectable via shift-click based on linear indices.
+
+## 12. Testing Requirements
+- Unit-test anchor updates, toggling logic, and range calculations across sort orders.
+- Verify that linear ordering remains stable as items load, unload, or reflow.
+- Compare interaction sequences against OS gallery applications to confirm matching expectations.
+- Add regression tests ensuring selection persists through viewport resizes and data updates.
+
+## 13. Summary
+Shift-click multi-selection must always respect the dataset's linear order and never rely on geometry. Accurate anchor management and separation between layout and selection data ensure deterministic, OS-consistent behavior across all user interactions.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1178,6 +1178,10 @@ function App() {
     [groupByFolders, randomSeed, renderLimitStep]
   );
 
+  useEffect(() => {
+    selection.resetAnchor?.();
+  }, [selection.resetAnchor, sortKey, sortDir]);
+
   const toggleGroupByFolders = useCallback(() => {
     const next = !groupByFolders;
     setGroupByFolders(next);

--- a/src/hooks/selection/useCardSelection.js
+++ b/src/hooks/selection/useCardSelection.js
@@ -1,9 +1,8 @@
 import { useCallback } from 'react';
-import useMasonryBoxSelection from './useMasonryBoxSelection';
 
 /**
  * Centralizes all per-card interactions:
- * - Click: single / ctrl-toggle / shift range (bounding box) / double → fullscreen
+ * - Click: single / ctrl-toggle / shift range (linear order) / double → fullscreen
  * - Right-click: open context menu without mutating selection
  * - Background right-click: dismiss custom menu without altering selection
  */
@@ -13,14 +12,13 @@ export default function useCardSelection({
   getById,
   openFullScreen,
   playingVideos,
+  getLinearOrder,
     // from useContextMenu – use the pair that matches your hook API
     showOnItem,     // (event, id)
     showOnEmpty,    // (event)
   // OR if you still expose a single function:
   showContextMenu // (event, video|null)
 }) {
-  const { selectRangeByBox } = useMasonryBoxSelection(gridRef);
-
   const handleVideoSelect = useCallback(
     (videoId, isCtrlClick, isShiftClick, isDoubleClick) => {
       const video = getById?.(videoId);
@@ -31,12 +29,17 @@ export default function useCardSelection({
       }
 
       if (isShiftClick) {
-        if (!selection.anchorId) {
+        const orderedIds =
+          typeof selection?.selectRange === 'function' &&
+          typeof getLinearOrder === 'function'
+            ? getLinearOrder() ?? []
+            : [];
+
+        if (orderedIds.length) {
+          selection.selectRange(orderedIds, videoId, isCtrlClick);
+        } else {
           selection.selectOnly(videoId);
-          return;
         }
-        // bounding-box range; additive when ctrl/meta held
-        selectRangeByBox(selection, selection.anchorId, videoId, isCtrlClick);
         return;
       }
 
@@ -46,7 +49,7 @@ export default function useCardSelection({
         selection.selectOnly(videoId);
       }
     },
-    [getById, openFullScreen, playingVideos, selection, selectRangeByBox]
+    [getById, openFullScreen, playingVideos, selection, getLinearOrder]
   );
 
   // Card context menu – select if needed then show the menu

--- a/src/hooks/selection/useCardSelection.test.js
+++ b/src/hooks/selection/useCardSelection.test.js
@@ -11,6 +11,7 @@ describe('useCardSelection', () => {
   let openFullScreen;
   let showOnItem;
   let showOnEmpty;
+  let getLinearOrder;
 
   beforeEach(() => {
     // Selection stub
@@ -24,8 +25,8 @@ describe('useCardSelection', () => {
       toggle: vi.fn((id) => {
         if (selection.selected.has(id)) selection.selected.delete(id);
         else selection.selected.add(id);
-        selection.anchorId = id;
       }),
+      selectRange: vi.fn(),
       clear: vi.fn(() => {
         selection.selected = new Set();
         selection.anchorId = null;
@@ -40,6 +41,7 @@ describe('useCardSelection', () => {
     openFullScreen = vi.fn();
     showOnItem = vi.fn();
     showOnEmpty = vi.fn();
+    getLinearOrder = vi.fn(() => ['a', 'b', 'c', 'd']);
 
     // jsdom root for querySelectorAll in inner hook (no actual items needed here for most tests)
     gridRef.current.innerHTML = '';
@@ -53,6 +55,7 @@ describe('useCardSelection', () => {
         getById,
         openFullScreen,
         playingVideos: new Set(),
+        getLinearOrder,
         showOnItem,
         showOnEmpty,
       })
@@ -81,6 +84,30 @@ describe('useCardSelection', () => {
     selection.anchorId = null;
 
     act(() => result.current.handleVideoSelect('x', false, true, false));
+    expect(selection.selectRange).toHaveBeenCalledWith(
+      ['a', 'b', 'c', 'd'],
+      'x',
+      false
+    );
+    expect(selection.selectOnly).not.toHaveBeenCalledWith('x');
+  });
+
+  test('shift-click falls back to single select when no linear order is provided', () => {
+    getLinearOrder = vi.fn(() => []);
+    const { result } = renderHook(() =>
+      useCardSelection({
+        gridRef,
+        selection,
+        getById,
+        openFullScreen,
+        playingVideos: new Set(),
+        getLinearOrder,
+        showOnItem,
+        showOnEmpty,
+      })
+    );
+
+    act(() => result.current.handleVideoSelect('x', false, true, false));
     expect(selection.selectOnly).toHaveBeenCalledWith('x');
   });
 
@@ -106,34 +133,18 @@ describe('useCardSelection', () => {
     expect(selection.clear).not.toHaveBeenCalled();
   });
 
-  test('shift-click with anchor uses bounding box (via setSelected)', () => {
-    // Build a tiny DOM so inner box-selection can work
-    const makeRect = (l, t, r, b) => ({ left: l, top: t, right: r, bottom: b, width: r-l, height: b-t });
-    gridRef.current.innerHTML = '';
-    const addItem = (id, rect) => {
-      const el = document.createElement('div');
-      el.className = 'video-item';
-      el.dataset.videoId = id;
-      el.getBoundingClientRect = vi.fn(() => rect);
-      gridRef.current.appendChild(el);
-    };
-    // anchor=a (0,0)-(100,80), end=b (110,0)-(210,60) → expect [a,b]
-    addItem('a', makeRect(0, 0, 100, 80));
-    addItem('b', makeRect(110, 0, 210, 60));
-    addItem('c', makeRect(220, 0, 320, 120)); // outside the box for this test
-
+  test('shift-click forwards linear order to selectRange', () => {
     const { result } = render();
     selection.anchorId = 'a';
 
     act(() => {
-      result.current.handleVideoSelect('b', /*ctrl*/ false, /*shift*/ true, /*dbl*/ false);
+      result.current.handleVideoSelect('c', false, true, false);
     });
 
-    // setSelected was called with a Set containing a & b (order not guaranteed)
-    expect(selection.setSelected).toHaveBeenCalled();
-    const arg = selection.setSelected.mock.calls.at(-1)[0];
-    const nextSet = typeof arg === 'function' ? arg(new Set()) : arg;
-    expect(nextSet instanceof Set).toBe(true);
-    expect(Array.from(nextSet).sort()).toEqual(['a', 'b']);
+    expect(selection.selectRange).toHaveBeenCalledWith(
+      ['a', 'b', 'c', 'd'],
+      'c',
+      false
+    );
   });
 });

--- a/src/hooks/selection/useSelectionState.js
+++ b/src/hooks/selection/useSelectionState.js
@@ -1,26 +1,15 @@
 // src/hooks/selection/useSelectionState.js
-import { useMemo, useState, useCallback } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 
 export default function useSelectionState() {
   const [selected, setSelected] = useState(() => new Set());
-  const [anchorId, setAnchorId] = useState(null); // NEW
+  const [anchorId, setAnchorId] = useState(null);
 
   const size = selected.size;
 
   const selectOnly = useCallback((id) => {
-    setSelected((prev) => {
-      const alreadyOnly = prev.size === 1 && prev.has(id);
-      if (alreadyOnly) {
-        setAnchorId(null);
-        return new Set();
-      }
-
-      // If the item was part of a larger selection we collapse down to just it;
-      // a subsequent click will hit the early return above and clear everything.
-      const next = new Set([id]);
-      setAnchorId(id); // set anchor for shift-range
-      return next;
-    });
+    setSelected(() => new Set(id ? [id] : []));
+    setAnchorId(id ?? null);
   }, []);
 
   const toggle = useCallback((id) => {
@@ -30,7 +19,6 @@ export default function useSelectionState() {
       else ns.add(id);
       return ns;
     });
-    setAnchorId(id); // update anchor on explicit click
   }, []);
 
   const clear = useCallback(() => {
@@ -40,22 +28,58 @@ export default function useSelectionState() {
 
   // Select a whole range, given the *ordered ids* array and the end id.
   const selectRange = useCallback((orderedIds, endId, additive = false) => {
-    if (!orderedIds?.length) return;
-    const a = anchorId ?? endId;
-    const i1 = orderedIds.indexOf(a);
-    const i2 = orderedIds.indexOf(endId);
-    if (i1 === -1 || i2 === -1) return;
+    if (!orderedIds?.length || !endId) return;
 
-    const [from, to] = i1 <= i2 ? [i1, i2] : [i2, i1];
-    const rangeIds = orderedIds.slice(from, to + 1);
+    setSelected((prev) => {
+      const ids = Array.isArray(orderedIds) ? orderedIds : [];
+      if (!ids.length) return prev;
 
-    setSelected(prev => {
-      const ns = additive ? new Set(prev) : new Set();
-      for (const id of rangeIds) ns.add(id);
-      return ns;
+      let effectiveAnchor = anchorId;
+      if (effectiveAnchor && !ids.includes(effectiveAnchor)) {
+        const fallback = ids.find((id) => prev.has(id));
+        effectiveAnchor = fallback ?? null;
+      }
+
+      if (!effectiveAnchor) {
+        effectiveAnchor = endId;
+      }
+
+      const endIndex = ids.indexOf(endId);
+      if (endIndex === -1) return prev;
+
+      const anchorIndex = ids.indexOf(effectiveAnchor);
+      const safeAnchorIndex = anchorIndex === -1 ? endIndex : anchorIndex;
+      const from = Math.min(safeAnchorIndex, endIndex);
+      const to = Math.max(safeAnchorIndex, endIndex);
+
+      const next = additive ? new Set(prev) : new Set();
+      for (let i = from; i <= to; i += 1) {
+        next.add(ids[i]);
+      }
+
+      setAnchorId(endId);
+      return next;
     });
-    setAnchorId(a); // keep the original anchor
   }, [anchorId]);
+
+  const resetAnchor = useCallback(() => {
+    setAnchorId(null);
+  }, []);
+
+  const setAnchor = useCallback((id) => {
+    setAnchorId(id ?? null);
+  }, []);
+
+  useEffect(() => {
+    if (anchorId && !selected.has(anchorId)) {
+      const iterator = selected.values();
+      const next = iterator.next();
+      const fallback = next?.value ?? null;
+      if (fallback !== anchorId) {
+        setAnchorId(fallback ?? null);
+      }
+    }
+  }, [anchorId, selected]);
 
   return {
     selected,
@@ -66,5 +90,7 @@ export default function useSelectionState() {
     toggle,
     clear,
     selectRange,
+    resetAnchor,
+    setAnchor,
   };
 }

--- a/src/hooks/selection/useSelectionState.test.js
+++ b/src/hooks/selection/useSelectionState.test.js
@@ -3,121 +3,121 @@ import { renderHook, act } from '@testing-library/react';
 import useSelectionState from './useSelectionState';
 
 describe('useSelectionState', () => {
-  test('selectOnly sets exactly one id', () => {
+  test('selectOnly sets exactly one id and anchor', () => {
     const { result } = renderHook(() => useSelectionState());
-    act(() => result.current.selectOnly('a'));
-    expect(result.current.selected.has('a')).toBe(true);
-    expect(result.current.selected.size).toBe(1);
-  });
-
-  test('selectOnly on the same id clears selection', () => {
-    const { result } = renderHook(() => useSelectionState());
-    act(() => result.current.selectOnly('a'));
-    expect(result.current.selected.size).toBe(1);
-    act(() => result.current.selectOnly('a'));
-    expect(result.current.selected.size).toBe(0);
-  });
-
-  test('selectOnly isolates a member of a multi-selection before clearing', () => {
-    const { result } = renderHook(() => useSelectionState());
-    act(() => result.current.selectOnly('a'));
-    act(() => result.current.toggle('b'));
-    expect(result.current.selected).toEqual(new Set(['a', 'b']));
-
     act(() => result.current.selectOnly('a'));
     expect(result.current.selected).toEqual(new Set(['a']));
     expect(result.current.anchorId).toBe('a');
+  });
 
+  test('selectOnly on the same id keeps anchor and selection', () => {
+    const { result } = renderHook(() => useSelectionState());
     act(() => result.current.selectOnly('a'));
-    expect(result.current.selected.size).toBe(0);
+    expect(result.current.selected.size).toBe(1);
+    act(() => result.current.selectOnly('a'));
+    expect(result.current.selected).toEqual(new Set(['a']));
+    expect(result.current.anchorId).toBe('a');
+  });
+
+  test('toggle modifies selection without changing anchor from last single click', () => {
+    const { result } = renderHook(() => useSelectionState());
+    act(() => result.current.selectOnly('a'));
+    expect(result.current.anchorId).toBe('a');
+
+    act(() => result.current.toggle('b'));
+    expect(result.current.selected).toEqual(new Set(['a', 'b']));
+    expect(result.current.anchorId).toBe('a');
+
+    act(() => result.current.toggle('b'));
+    expect(result.current.selected).toEqual(new Set(['a']));
+    expect(result.current.anchorId).toBe('a');
+  });
+
+  test('toggle without prior anchor leaves anchor unset', () => {
+    const { result } = renderHook(() => useSelectionState());
+    act(() => result.current.toggle('a'));
+    expect(result.current.selected).toEqual(new Set(['a']));
     expect(result.current.anchorId).toBe(null);
   });
 
-  test('toggle adds/removes', () => {
+  test('resetAnchor clears anchor without altering selection', () => {
     const { result } = renderHook(() => useSelectionState());
-    act(() => result.current.toggle('a'));
-    expect(result.current.selected.has('a')).toBe(true);
-    act(() => result.current.toggle('a'));
-    expect(result.current.selected.has('a')).toBe(false);
+    act(() => result.current.selectOnly('a'));
+    expect(result.current.anchorId).toBe('a');
+    act(() => result.current.resetAnchor());
+    expect(result.current.anchorId).toBe(null);
+    expect(result.current.selected).toEqual(new Set(['a']));
   });
 
-  test('clear empties selection', () => {
+  test('clear empties selection and anchor', () => {
     const { result } = renderHook(() => useSelectionState());
     act(() => result.current.selectOnly('x'));
     act(() => result.current.clear());
     expect(result.current.selected.size).toBe(0);
+    expect(result.current.anchorId).toBe(null);
   });
 });
 
 const ids = ['a', 'b', 'c', 'd', 'e'];
 
 describe('useSelectionState (range + anchor)', () => {
-  test('selectOnly sets exactly one id and anchor', () => {
+  test('selectRange uses anchor → end (forward) and updates anchor to clicked id', () => {
     const { result } = renderHook(() => useSelectionState());
-    act(() => result.current.selectOnly('c'));
-    expect(result.current.selected.size).toBe(1);
-    expect(result.current.selected.has('c')).toBe(true);
-    expect(result.current.anchorId).toBe('c');
-  });
-
-  test('selectOnly toggled clears anchor', () => {
-    const { result } = renderHook(() => useSelectionState());
-    act(() => result.current.selectOnly('c'));
-    expect(result.current.anchorId).toBe('c');
-    act(() => result.current.selectOnly('c'));
-    expect(result.current.selected.size).toBe(0);
-    expect(result.current.anchorId).toBe(null);
-  });
-
-  test('toggle adds/removes and updates anchor', () => {
-    const { result } = renderHook(() => useSelectionState());
-    act(() => result.current.toggle('a'));
-    expect(result.current.selected.has('a')).toBe(true);
-    expect(result.current.anchorId).toBe('a');
-    act(() => result.current.toggle('a'));
-    expect(result.current.selected.has('a')).toBe(false);
-    // we keep last anchor (this is a policy choice; adjust if your hook resets it)
-    expect(result.current.anchorId).toBe('a');
-  });
-
-  test('selectRange uses anchor → end (forward)', () => {
-    const { result } = renderHook(() => useSelectionState());
-    act(() => result.current.selectOnly('b')); // anchor = b
+    act(() => result.current.selectOnly('b'));
     act(() => result.current.selectRange(ids, 'd', false));
     expect(result.current.selected).toEqual(new Set(['b', 'c', 'd']));
+    expect(result.current.anchorId).toBe('d');
   });
 
-  test('selectRange handles reverse (end before anchor)', () => {
+  test('selectRange handles reverse order and updates anchor', () => {
     const { result } = renderHook(() => useSelectionState());
-    act(() => result.current.selectOnly('d')); // anchor = d
+    act(() => result.current.selectOnly('d'));
     act(() => result.current.selectRange(ids, 'b', false));
     expect(result.current.selected).toEqual(new Set(['b', 'c', 'd']));
+    expect(result.current.anchorId).toBe('b');
   });
 
-  test('selectRange additive=true merges with existing selection', () => {
+  test('selectRange additive=true merges with existing selection and updates anchor', () => {
     const { result } = renderHook(() => useSelectionState());
-    act(() => result.current.selectOnly('a'));          // anchor = a ; selected={a}
-    act(() => result.current.selectRange(ids, 'c', true)); // add {a,b,c}
+    act(() => result.current.selectOnly('a'));
+    act(() => result.current.selectRange(ids, 'c', true));
     expect(result.current.selected).toEqual(new Set(['a', 'b', 'c']));
-    // Now set a new anchor and add another range
-    act(() => result.current.selectOnly('e'));          // anchor=e; selected={e}
-    act(() => result.current.selectRange(ids, 'c', true)); // add {c,d,e}
+    expect(result.current.anchorId).toBe('c');
+
+    act(() => result.current.selectOnly('e'));
+    act(() => result.current.selectRange(ids, 'c', true));
     expect(result.current.selected).toEqual(new Set(['c', 'd', 'e']));
+    expect(result.current.anchorId).toBe('c');
   });
 
   test('selectRange with no anchor behaves like single select', () => {
     const { result } = renderHook(() => useSelectionState());
-    // anchorId starts null; hook should default to endId -> single select
     act(() => result.current.selectRange(ids, 'c', false));
     expect(result.current.selected).toEqual(new Set(['c']));
     expect(result.current.anchorId).toBe('c');
   });
 
-  test('clear empties selection and resets anchor', () => {
+  test('selectRange falls back to earliest selected id when anchor is missing', () => {
     const { result } = renderHook(() => useSelectionState());
-    act(() => result.current.selectOnly('x'));
-    act(() => result.current.clear());
-    expect(result.current.selected.size).toBe(0);
-    expect(result.current.anchorId).toBe(null);
+    act(() => result.current.selectOnly('c'));
+    act(() => result.current.setAnchor('z'));
+    act(() => result.current.selectRange(ids, 'e', false));
+    expect(result.current.selected).toEqual(new Set(['c', 'd', 'e']));
+    expect(result.current.anchorId).toBe('e');
+  });
+
+  test('anchor reassigns when anchor item is removed from selection', () => {
+    const { result } = renderHook(() => useSelectionState());
+    act(() => result.current.selectOnly('b'));
+    act(() =>
+      result.current.setSelected((prev) => {
+        const ns = new Set(prev);
+        ns.delete('b');
+        ns.add('d');
+        return ns;
+      })
+    );
+    expect(result.current.selected).toEqual(new Set(['d']));
+    expect(result.current.anchorId).toBe('d');
   });
 });


### PR DESCRIPTION
## Summary
- update the selection state hook to manage anchors purely by linear dataset order, including range selection, anchor resets, and removal fallback
- route shift-click handling through linear order in the card selection hook and broaden tests for keyboard/mouse interactions
- reset anchors on sort changes and expand unit coverage for the new anchor semantics

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69171b440a10832cbbfd225a4e6417a0)