### PR TITLE
Refine masonry sort relayout trigger with stable order guard

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1108,10 +1108,24 @@ function App() {
   ]);
 
   // === DYNAMIC ZOOM RESIZE / COUNT ===
-  // relayout when list changes
+  // relayout when list order or membership changes
+  const previousOrderedIdsRef = useRef(null);
   useEffect(() => {
-    if (orderedVideos.length) onItemsChanged();
-  }, [orderedVideos.length, onItemsChanged]);
+    const nextOrderedIds = Array.isArray(orderedIds) ? orderedIds : [];
+    const previousOrderedIds = previousOrderedIdsRef.current;
+
+    const orderChanged =
+      !Array.isArray(previousOrderedIds) ||
+      previousOrderedIds.length !== nextOrderedIds.length ||
+      nextOrderedIds.some((id, index) => id !== previousOrderedIds[index]);
+
+    if (!orderChanged) {
+      return;
+    }
+
+    previousOrderedIdsRef.current = nextOrderedIds.slice();
+    onItemsChanged();
+  }, [orderedIds, onItemsChanged]);
 
   // aspect ratio updates from cards
     const handleVideoLoaded = useCallback(

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -288,3 +288,36 @@ describe("App hook composition", () => {
     result.unmount();
   });
 });
+
+
+describe("App masonry relayout behavior", () => {
+  test("re-layouts only when ordered ids meaningfully change", async () => {
+    const onItemsChanged = vi.fn();
+    let ids = ["a", "b", "c"];
+
+    useMasonryLayoutMock.mockImplementation(() => ({
+      ...masonryReturn,
+      orderedIds: [...ids],
+      orderedVideos: ids.map((id) => ({ id, basename: id, dirname: "" })),
+      onItemsChanged,
+    }));
+
+    vi.resetModules();
+    const { default: App } = await import("./App.jsx");
+
+    const result = render(<App />);
+    expect(onItemsChanged).toHaveBeenCalledTimes(1);
+
+    // Same semantic order (new array identity) should not force another relayout.
+    ids = ["a", "b", "c"];
+    result.rerender(<App />);
+    expect(onItemsChanged).toHaveBeenCalledTimes(1);
+
+    // Order change should trigger relayout.
+    ids = ["c", "b", "a"];
+    result.rerender(<App />);
+    expect(onItemsChanged).toHaveBeenCalledTimes(2);
+
+    result.unmount();
+  });
+});


### PR DESCRIPTION
### Motivation
- Sorting changes could leave the masonry grid visually stale unless a relayout ran, but the prior fix that triggered on `orderedIds` identity caused unnecessary relayouts when an equivalent array instance was recreated.
- The intent is to keep the visual correctness (invalidate cached measurements when order/membership changes) while avoiding extra layout churn for no-op rerenders.

### Description
- Replace the naive dependency-based relayout in `App.jsx` with a semantic comparison: add `previousOrderedIdsRef` and call `onItemsChanged()` only when `orderedIds` content or length actually changes, keeping the effect dependent on `orderedIds` and `onItemsChanged`.
- Remove reliance on `orderedVideos.length` for triggering relayout and instead compare element-by-element to detect real order/membership changes.
- Add a regression test in `src/App.test.jsx` that mocks `onItemsChanged` and verifies that an equivalent `orderedIds` array (new identity) does not trigger a relayout while an actual order change does.

### Testing
- Ran `npm test -- src/App.test.jsx src/sorting/__tests__/sorting.test.js src/hooks/video-collection/useProgressiveList.test.js` and all test files succeeded.
- Test summary: 3 test files, 15 tests total, all passed; the new `App masonry relayout behavior` test passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ce27acbb4832ca2dabdb11dae592c)