### PR TITLE
Add Hover audio toggle and orchestrated hover-audio playback

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -142,6 +142,7 @@ function App() {
   const selectionSetSelected = selection.setSelected;
   const [recursiveMode, setRecursiveMode] = useState(false);
   const [showFilenames, setShowFilenames] = useState(true);
+  const [hoverAudioEnabled, setHoverAudioEnabled] = useState(false);
   const [renderLimitStep, setRenderLimitStep] = useState(RENDER_LIMIT_STEPS);
   const [zoomLevel, setZoomLevel] = useState(1);
   const [sortKey, setSortKey] = useState(SortKey.NAME);
@@ -1017,6 +1018,7 @@ function App() {
     activationWindowIds: activationWindow.ids,
     suspendEvictions: isLayoutTransitioning,
     renderLimit: renderLimitValue,
+    hoverAudioEnabled,
   });
 
   // fullscreen / context menu
@@ -1373,6 +1375,8 @@ function App() {
             toggleRecursive={toggleRecursive}
             showFilenames={showFilenames}
             toggleFilenames={toggleFilenames}
+            hoverAudioEnabled={hoverAudioEnabled}
+            onHoverAudioToggle={setHoverAudioEnabled}
             renderLimitStep={renderLimitStep}
             renderLimitLabel={renderLimitLabel}
             renderLimitMaxStep={RENDER_LIMIT_STEPS}
@@ -1587,6 +1591,12 @@ function App() {
                     }}
                     // Hover for priority
                     onHover={(id) => videoCollection.markHover(id)}
+                    hoverAudioEnabled={hoverAudioEnabled}
+                    isHoverAudioActive={
+                      hoverAudioEnabled && videoCollection.activeHoverAudioId === video.id
+                    }
+                    onHoverAudioStart={videoCollection.onCardHoverAudioStart}
+                    onHoverAudioEnd={videoCollection.onCardHoverAudioEnd}
                     scheduleInit={scheduleInit}
                   />
                 ))}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1158,6 +1158,10 @@ function App() {
     });
   }, [showFilenames, recursiveMode, renderLimitStep, zoomLevel]);
 
+  const toggleHoverAudio = useCallback(() => {
+    setHoverAudioEnabled((prev) => !prev);
+  }, []);
+
   const handleRenderLimitStepChange = useCallback(
     (step) => {
       const clamped = clampRenderLimitStep(step);
@@ -1376,7 +1380,7 @@ function App() {
             showFilenames={showFilenames}
             toggleFilenames={toggleFilenames}
             hoverAudioEnabled={hoverAudioEnabled}
-            onHoverAudioToggle={setHoverAudioEnabled}
+            onHoverAudioToggle={toggleHoverAudio}
             renderLimitStep={renderLimitStep}
             renderLimitLabel={renderLimitLabel}
             renderLimitMaxStep={RENDER_LIMIT_STEPS}

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -170,15 +170,14 @@ vi.mock("./components/HeaderBar", () => ({
   default: (props) => {
     headerBarSpy(props);
     return (
-      <label>
+      <button
+        type="button"
+        aria-label="Play audio on hover"
+        aria-pressed={Boolean(props.hoverAudioEnabled)}
+        onClick={() => props.onHoverAudioToggle?.()}
+      >
         Hover audio
-        <input
-          aria-label="Hover audio"
-          type="checkbox"
-          checked={Boolean(props.hoverAudioEnabled)}
-          onChange={(e) => props.onHoverAudioToggle?.(e.target.checked)}
-        />
-      </label>
+      </button>
     );
   },
 }));
@@ -311,7 +310,7 @@ describe("App hook composition", () => {
 
     render(<App />);
 
-    const hoverAudioToggle = screen.getByRole("checkbox", { name: "Hover audio" });
+    const hoverAudioToggle = screen.getByRole("button", { name: "Play audio on hover" });
     expect(hoverAudioToggle).toBeInTheDocument();
     expect(useVideoCollectionMock).toHaveBeenCalled();
 

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { describe, test, expect, afterEach, vi } from "vitest";
-import { render, cleanup } from "@testing-library/react";
+import { render, cleanup, fireEvent, screen } from "@testing-library/react";
 
 const selectionMock = {
   selected: new Set(),
@@ -139,7 +139,11 @@ const useVideoCollectionMock = vi.fn(() => ({
   reportStarted: vi.fn(),
   reportPlayError: vi.fn(),
   markHover: vi.fn(),
+  activeHoverAudioId: null,
+  onCardHoverAudioStart: vi.fn(),
+  onCardHoverAudioEnd: vi.fn(),
 }));
+const headerBarSpy = vi.fn();
 
 vi.mock("./components/VideoCard/VideoCard", () => ({
   __esModule: true,
@@ -163,7 +167,20 @@ vi.mock("./components/MetadataPanel", () => ({
 }));
 vi.mock("./components/HeaderBar", () => ({
   __esModule: true,
-  default: () => null,
+  default: (props) => {
+    headerBarSpy(props);
+    return (
+      <label>
+        Hover audio
+        <input
+          aria-label="Hover audio"
+          type="checkbox"
+          checked={Boolean(props.hoverAudioEnabled)}
+          onChange={(e) => props.onHoverAudioToggle?.(e.target.checked)}
+        />
+      </label>
+    );
+  },
 }));
 vi.mock("./components/FiltersPopover", async () => {
   const ReactModule = await vi.importActual("react");
@@ -286,5 +303,25 @@ describe("App hook composition", () => {
     expect(zoomArgs.runWithStableAnchor).toBe(runWithStableAnchorMock);
 
     result.unmount();
+  });
+
+  test("wires Hover audio header toggle into useVideoCollection state", async () => {
+    vi.resetModules();
+    const { default: App } = await import("./App.jsx");
+
+    render(<App />);
+
+    const hoverAudioToggle = screen.getByRole("checkbox", { name: "Hover audio" });
+    expect(hoverAudioToggle).toBeInTheDocument();
+    expect(useVideoCollectionMock).toHaveBeenCalled();
+
+    const initialArgs = useVideoCollectionMock.mock.calls.at(-1)?.[0];
+    expect(initialArgs.hoverAudioEnabled).toBe(false);
+
+    fireEvent.click(hoverAudioToggle);
+
+    const updatedArgs = useVideoCollectionMock.mock.calls.at(-1)?.[0];
+    expect(updatedArgs.hoverAudioEnabled).toBe(true);
+    expect(headerBarSpy).toHaveBeenCalled();
   });
 });

--- a/src/components/HeaderBar.jsx
+++ b/src/components/HeaderBar.jsx
@@ -90,6 +90,22 @@ const FilterIcon = (props) => (
   </Icon>
 );
 
+const SpeakerOnIcon = (props) => (
+  <Icon {...props}>
+    <polygon points="11 5 6 9 3 9 3 15 6 15 11 19 11 5" />
+    <path d="M15.5 8.5a5 5 0 0 1 0 7" />
+    <path d="M18.5 6a8.5 8.5 0 0 1 0 12" />
+  </Icon>
+);
+
+const SpeakerOffIcon = (props) => (
+  <Icon {...props}>
+    <polygon points="11 5 6 9 3 9 3 15 6 15 11 19 11 5" />
+    <line x1="23" y1="9" x2="17" y2="15" />
+    <line x1="17" y1="9" x2="23" y2="15" />
+  </Icon>
+);
+
 export default function HeaderBar({
   isLoadingFolder,
   handleFolderSelect,
@@ -174,16 +190,6 @@ export default function HeaderBar({
           <span>Subfolders</span>
         </label>
 
-        <label className="subfolders-option" title="Enable audio while hovering cards">
-          <input
-            type="checkbox"
-            checked={hoverAudioEnabled}
-            onChange={(e) => onHoverAudioToggle?.(e.target.checked)}
-            disabled={isLoadingFolder}
-          />
-          <span>Hover audio</span>
-        </label>
-
         {hasOpenFolder && recentFolders.length > 0 && (
           <RecentLocationsMenu items={recentFolders} onOpen={onRecentOpen} />
         )}
@@ -220,6 +226,19 @@ export default function HeaderBar({
           </div>
 
           <div className="zoom-control" title="Zoom">
+            <button
+              onClick={() => onHoverAudioToggle?.()}
+              className={`toggle-button ${hoverAudioEnabled ? "active" : ""}`}
+              disabled={isLoadingFolder}
+              title="Play audio on hover"
+              aria-label="Play audio on hover"
+              aria-pressed={hoverAudioEnabled}
+              type="button"
+              style={{ opacity: hoverAudioEnabled ? 1 : 0.75 }}
+            >
+              {hoverAudioEnabled ? <SpeakerOnIcon /> : <SpeakerOffIcon />}
+            </button>
+
             <ZoomInIcon />
             <input
               type="range"

--- a/src/components/HeaderBar.jsx
+++ b/src/components/HeaderBar.jsx
@@ -118,6 +118,8 @@ export default function HeaderBar({
   filtersActiveCount = 0,
   filtersAreOpen = false,
   filtersButtonRef,
+  hoverAudioEnabled = false,
+  onHoverAudioToggle,
 }) {
   const isElectron = !!window.electronAPI?.isElectron;
 
@@ -170,6 +172,16 @@ export default function HeaderBar({
             disabled={isLoadingFolder}
           />
           <span>Subfolders</span>
+        </label>
+
+        <label className="subfolders-option" title="Enable audio while hovering cards">
+          <input
+            type="checkbox"
+            checked={hoverAudioEnabled}
+            onChange={(e) => onHoverAudioToggle?.(e.target.checked)}
+            disabled={isLoadingFolder}
+          />
+          <span>Hover audio</span>
         </label>
 
         {hasOpenFolder && recentFolders.length > 0 && (

--- a/src/components/HeaderBar.test.jsx
+++ b/src/components/HeaderBar.test.jsx
@@ -1,0 +1,82 @@
+import React from "react";
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, within, fireEvent } from "@testing-library/react";
+import HeaderBar from "./HeaderBar";
+
+const baseProps = {
+  isLoadingFolder: false,
+  handleFolderSelect: vi.fn(),
+  handleWebFileSelection: vi.fn(),
+  recursiveMode: false,
+  toggleRecursive: vi.fn(),
+  showFilenames: true,
+  toggleFilenames: vi.fn(),
+  renderLimitStep: 2,
+  renderLimitLabel: "200",
+  renderLimitMaxStep: 10,
+  handleRenderLimitChange: vi.fn(),
+  zoomLevel: 1,
+  handleZoomChangeSafe: vi.fn(),
+  getMinimumZoomLevel: vi.fn(() => 0),
+  sortKey: "name",
+  sortSelection: "name-asc",
+  groupByFolders: true,
+  onSortChange: vi.fn(),
+  onGroupByFoldersToggle: vi.fn(),
+  onReshuffle: vi.fn(),
+  recentFolders: [],
+  onRecentOpen: vi.fn(),
+  hasOpenFolder: true,
+  onFiltersToggle: vi.fn(),
+  filtersActiveCount: 0,
+  filtersAreOpen: false,
+  filtersButtonRef: { current: null },
+  hoverAudioEnabled: false,
+  onHoverAudioToggle: vi.fn(),
+};
+
+describe("HeaderBar hover audio control", () => {
+  it("renders as icon toggle in right interaction cluster, not left checkbox text", () => {
+    const { container } = render(<HeaderBar {...baseProps} />);
+
+    const hoverAudioButton = screen.getByRole("button", {
+      name: "Play audio on hover",
+    });
+    expect(hoverAudioButton).toBeInTheDocument();
+    expect(hoverAudioButton).toHaveAttribute("title", "Play audio on hover");
+
+    const navLeft = container.querySelector(".nav-left");
+    expect(navLeft).toBeTruthy();
+    expect(within(navLeft).queryByText("Hover audio")).toBeNull();
+  });
+
+  it("click toggles callback and active state is reflected", () => {
+    const onHoverAudioToggle = vi.fn();
+    const { rerender } = render(
+      <HeaderBar
+        {...baseProps}
+        hoverAudioEnabled={false}
+        onHoverAudioToggle={onHoverAudioToggle}
+      />
+    );
+
+    const button = screen.getByRole("button", { name: "Play audio on hover" });
+    expect(button).toHaveAttribute("aria-pressed", "false");
+    expect(button.className).not.toContain("active");
+
+    fireEvent.click(button);
+    expect(onHoverAudioToggle).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <HeaderBar
+        {...baseProps}
+        hoverAudioEnabled={true}
+        onHoverAudioToggle={onHoverAudioToggle}
+      />
+    );
+
+    const activeButton = screen.getByRole("button", { name: "Play audio on hover" });
+    expect(activeButton).toHaveAttribute("aria-pressed", "true");
+    expect(activeButton.className).toContain("active");
+  });
+});

--- a/src/components/VideoCard/VideoCard.jsx
+++ b/src/components/VideoCard/VideoCard.jsx
@@ -30,6 +30,10 @@ const VideoCard = memo(function VideoCard({
   reportPlayerCreationFailure,
   onVisibilityChange,     // (id, visible)
   onHover,                // (id)
+  hoverAudioEnabled = false,
+  isHoverAudioActive = false,
+  onHoverAudioStart,      // (id)
+  onHoverAudioEnd,        // (id)
 
   // IO registry
   observeIntersection,    // (el, id, cb)
@@ -292,10 +296,27 @@ const VideoCard = memo(function VideoCard({
     el.addEventListener("pause",   handlePause);
     el.addEventListener("error",   handleError);
 
-    if (isPlaying && isVisible && loaded && !permanentErrorRef.current) {
+    const shouldPlay = isPlaying && isVisible && loaded && !permanentErrorRef.current;
+    if (shouldPlay) {
+      el.muted = !isHoverAudioActive;
+      if (isHoverAudioActive) {
+        el.volume = 1;
+      }
       const p = el.play();
-      if (p?.catch) p.catch((err) => handleError({ target: { error: err } }));
+      if (p?.catch) {
+        p.catch((err) => {
+          if (isHoverAudioActive && err?.name === "NotAllowedError") {
+            try {
+              el.muted = true;
+              el.play()?.catch?.(() => {});
+            } catch {}
+            return;
+          }
+          handleError({ target: { error: err } });
+        });
+      }
     } else {
+      el.muted = true;
       try { el.pause(); } catch {}
     }
 
@@ -304,7 +325,16 @@ const VideoCard = memo(function VideoCard({
       el.removeEventListener("pause",   handlePause);
       el.removeEventListener("error",   handleError);
     };
-  }, [isPlaying, isVisible, loaded, videoId, onVideoPlay, onVideoPause, onPlayError]);
+  }, [
+    isPlaying,
+    isVisible,
+    loaded,
+    isHoverAudioActive,
+    videoId,
+    onVideoPlay,
+    onVideoPause,
+    onPlayError,
+  ]);
 
   // Quiet stall watchdog (no visual changes)
   useEffect(() => {
@@ -683,8 +713,9 @@ const VideoCard = memo(function VideoCard({
       videoRef.current = null;
       loadRequestedRef.current = false;
       metaNotifiedRef.current = false;
+      onHoverAudioEnd?.(videoId);
     };
-  }, []);
+  }, [onHoverAudioEnd, videoId]);
 
   // UI handlers (unchanged)
   const handleClick = useCallback((e) => {
@@ -707,7 +738,18 @@ const VideoCard = memo(function VideoCard({
     onContextMenu?.(e, video);
   }, [onContextMenu, video]);
 
-  const handleMouseEnter = useCallback(() => onHover?.(videoId), [onHover, videoId]);
+  const handleMouseEnter = useCallback(() => {
+    onHover?.(videoId);
+    if (hoverAudioEnabled) {
+      onHoverAudioStart?.(videoId);
+    }
+  }, [onHover, videoId, hoverAudioEnabled, onHoverAudioStart]);
+
+  const handleMouseLeave = useCallback(() => {
+    if (hoverAudioEnabled) {
+      onHoverAudioEnd?.(videoId);
+    }
+  }, [hoverAudioEnabled, onHoverAudioEnd, videoId]);
 
   const handleDragStart = useCallback(
     (reactEvent) => {
@@ -801,6 +843,7 @@ const VideoCard = memo(function VideoCard({
       className={`video-item ${selected ? "selected" : ""} ${loading ? "loading" : ""}`}
       onClick={handleClick}
       onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
       onContextMenu={handleContextMenu}
       onDragStart={handleDragStart}
       draggable={canStartNativeDrag}

--- a/src/components/VideoCard/__tests__/ui.test.jsx
+++ b/src/components/VideoCard/__tests__/ui.test.jsx
@@ -1,7 +1,7 @@
 // src/components/VideoCard/VideoCard.test.jsx
 import React from "react";
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { render, screen, act } from "@testing-library/react";
+import { render, screen, act, fireEvent } from "@testing-library/react";
 import VideoCard from "../VideoCard";
 
 // Keep a handle to the native createElement so our mocks can delegate safely
@@ -540,5 +540,102 @@ describe("VideoCard", () => {
 
     containerEl = document.querySelector(".video-container");
     expect(containerEl?.contains(created)).toBe(true);
+  });
+
+  it("does not emit hover-audio callbacks when hover audio is disabled", () => {
+    const onHoverAudioStart = vi.fn();
+    const onHoverAudioEnd = vi.fn();
+
+    const { container } = render(
+      <VideoCard
+        {...baseProps}
+        video={{ id: "hover-1", name: "hover-1" }}
+        hoverAudioEnabled={false}
+        onHoverAudioStart={onHoverAudioStart}
+        onHoverAudioEnd={onHoverAudioEnd}
+      />
+    );
+
+    const card = container.querySelector(".video-item");
+    expect(card).toBeTruthy();
+    fireEvent.mouseEnter(card);
+    fireEvent.mouseLeave(card);
+
+    expect(onHoverAudioStart).not.toHaveBeenCalled();
+    expect(onHoverAudioEnd).not.toHaveBeenCalled();
+  });
+
+  it("emits hover-audio callbacks when hover audio is enabled", () => {
+    const onHoverAudioStart = vi.fn();
+    const onHoverAudioEnd = vi.fn();
+
+    const { container } = render(
+      <VideoCard
+        {...baseProps}
+        video={{ id: "hover-2", name: "hover-2" }}
+        hoverAudioEnabled={true}
+        onHoverAudioStart={onHoverAudioStart}
+        onHoverAudioEnd={onHoverAudioEnd}
+      />
+    );
+
+    const card = container.querySelector(".video-item");
+    expect(card).toBeTruthy();
+    fireEvent.mouseEnter(card);
+    fireEvent.mouseLeave(card);
+
+    expect(onHoverAudioStart).toHaveBeenCalledWith("hover-2");
+    expect(onHoverAudioEnd).toHaveBeenCalledWith("hover-2");
+  });
+
+  it("unmutes active hover-audio card and mutes inactive cards", async () => {
+    const video = {
+      id: "hover-audio-media",
+      name: "hover-audio-media",
+      isElectronFile: false,
+      fullPath: "/remote/hover-audio-media.mp4",
+    };
+    const { rerender } = render(
+      <VideoCard
+        {...baseProps}
+        video={video}
+        isPlaying={true}
+        isVisible={true}
+        isLoaded={false}
+      />
+    );
+
+    await act(async () => {});
+    const created = lastVideoEl;
+    expect(created).toBeTruthy();
+
+    await act(async () => {
+      created.dispatchEvent?.(new Event("loadedmetadata"));
+      created.dispatchEvent?.(new Event("loadeddata"));
+    });
+
+    rerender(
+      <VideoCard
+        {...baseProps}
+        video={video}
+        isPlaying={true}
+        isVisible={true}
+        isLoaded={true}
+        isHoverAudioActive={false}
+      />
+    );
+    expect(created.muted).toBe(true);
+
+    rerender(
+      <VideoCard
+        {...baseProps}
+        video={video}
+        isPlaying={true}
+        isVisible={true}
+        isLoaded={true}
+        isHoverAudioActive={true}
+      />
+    );
+    expect(created.muted).toBe(false);
   });
 });

--- a/src/hooks/video-collection/usePlayOrchestrator.js
+++ b/src/hooks/video-collection/usePlayOrchestrator.js
@@ -11,8 +11,10 @@ export default function usePlayOrchestrator({
   visibleIds, // Set<string>
   loadedIds, // Set<string>
   maxPlaying, // number
+  hoverAudioEnabled = false,
 }) {
   const [playingSet, setPlayingSet] = useState(new Set()); // allowed/desired
+  const [activeHoverAudioId, setActiveHoverAudioId] = useState(null);
   const hoveredRef = useRef(null);
   const startOrderRef = useRef([]); // newer at the end
   const recentlyErroredRef = useRef(new Map()); // id -> ts
@@ -158,10 +160,38 @@ export default function usePlayOrchestrator({
     [reconcile]
   );
 
+  const onCardHoverAudioStart = useCallback(
+    (id) => {
+      if (!hoverAudioEnabled) return;
+      setActiveHoverAudioId((prev) => (prev === id ? prev : id));
+    },
+    [hoverAudioEnabled]
+  );
+
+  const onCardHoverAudioEnd = useCallback(
+    (id) => {
+      setActiveHoverAudioId((prev) => (prev === id ? null : prev));
+    },
+    []
+  );
+
   // FIXED: Add proper dependency management for reconcile
   useEffect(() => {
     reconcile();
   }, [reconcile, visibleIds, loadedIds, maxPlaying]);
+
+  useEffect(() => {
+    if (hoverAudioEnabled) return;
+    setActiveHoverAudioId(null);
+  }, [hoverAudioEnabled]);
+
+  useEffect(() => {
+    setActiveHoverAudioId((prev) => {
+      if (!prev) return prev;
+      if (!visibleIds.has(prev)) return null;
+      return prev;
+    });
+  }, [visibleIds]);
 
   // Expire "recently errored" entries so they can retry later
   useEffect(() => {
@@ -181,9 +211,20 @@ export default function usePlayOrchestrator({
     () => ({
       playingSet, // desired/allowed
       markHover, // force-priority on hover
+      activeHoverAudioId,
+      onCardHoverAudioStart,
+      onCardHoverAudioEnd,
       reportStarted, // call when <video> fires "playing"
       reportPlayError, // call on error (load/play)
     }),
-    [playingSet, markHover, reportStarted, reportPlayError]
+    [
+      playingSet,
+      markHover,
+      activeHoverAudioId,
+      onCardHoverAudioStart,
+      onCardHoverAudioEnd,
+      reportStarted,
+      reportPlayError,
+    ]
   );
 }

--- a/src/hooks/video-collection/usePlayOrchestrator.test.js
+++ b/src/hooks/video-collection/usePlayOrchestrator.test.js
@@ -109,4 +109,63 @@ describe('usePlayOrchestrator', () => {
     expect(result.current.playingSet.has('keep')).toBe(true);
     expect(result.current.playingSet.has('reload')).toBe(false);
   });
+
+  test('hover audio start/end tracks active card and switches cleanly', () => {
+    const visible = setOf(['a', 'b']);
+    const loaded = setOf(['a', 'b']);
+    const { result } = renderHook(() =>
+      usePlayOrchestrator({
+        visibleIds: visible,
+        loadedIds: loaded,
+        maxPlaying: 2,
+        hoverAudioEnabled: true,
+      })
+    );
+
+    act(() => {
+      result.current.onCardHoverAudioStart('a');
+    });
+    expect(result.current.activeHoverAudioId).toBe('a');
+
+    act(() => {
+      result.current.onCardHoverAudioStart('b');
+    });
+    expect(result.current.activeHoverAudioId).toBe('b');
+
+    act(() => {
+      result.current.onCardHoverAudioEnd('a');
+    });
+    expect(result.current.activeHoverAudioId).toBe('b');
+
+    act(() => {
+      result.current.onCardHoverAudioEnd('b');
+    });
+    expect(result.current.activeHoverAudioId).toBe(null);
+  });
+
+  test('disabling hover audio clears active hover-audio state', () => {
+    const visible = setOf(['a']);
+    const loaded = setOf(['a']);
+    const { result, rerender } = renderHook((props) => usePlayOrchestrator(props), {
+      initialProps: {
+        visibleIds: visible,
+        loadedIds: loaded,
+        maxPlaying: 2,
+        hoverAudioEnabled: true,
+      },
+    });
+
+    act(() => {
+      result.current.onCardHoverAudioStart('a');
+    });
+    expect(result.current.activeHoverAudioId).toBe('a');
+
+    rerender({
+      visibleIds: visible,
+      loadedIds: loaded,
+      maxPlaying: 2,
+      hoverAudioEnabled: false,
+    });
+    expect(result.current.activeHoverAudioId).toBe(null);
+  });
 });

--- a/src/hooks/video-collection/useVideoCollection.js
+++ b/src/hooks/video-collection/useVideoCollection.js
@@ -29,6 +29,7 @@ export default function useVideoCollection({
   activationWindowIds = [],
   suspendEvictions = false,
   renderLimit = null,
+  hoverAudioEnabled = false,
 }) {
   const {
     initial = PROGRESSIVE_DEFAULTS.initial,
@@ -152,7 +153,15 @@ export default function useVideoCollection({
     cappedDesiredActiveCount && cappedDesiredActiveCount > 0
       ? Math.floor(cappedDesiredActiveCount)
       : limitedVisibleCount;
-  const { playingSet, markHover, reportPlayError, reportStarted } =
+  const {
+    playingSet,
+    markHover,
+    reportPlayError,
+    reportStarted,
+    activeHoverAudioId,
+    onCardHoverAudioStart,
+    onCardHoverAudioEnd,
+  } =
     usePlayOrchestrator({
       visibleIds: visibleVideos,
       loadedIds: loadedVideos,
@@ -160,6 +169,7 @@ export default function useVideoCollection({
         Number.isFinite(playingCap) && playingCap > 0
           ? playingCap
           : limitedVisibleCount,
+      hoverAudioEnabled,
     });
 
   return {
@@ -170,6 +180,9 @@ export default function useVideoCollection({
     canLoadVideo,
     isVideoPlaying: (videoId) => playingSet.has(videoId),
     markHover,
+    activeHoverAudioId,
+    onCardHoverAudioStart,
+    onCardHoverAudioEnd,
     reportPlayError,
     reportStarted,
     reportPlayerCreationFailure,

--- a/src/hooks/video-collection/useVideoCollection.test.js
+++ b/src/hooks/video-collection/useVideoCollection.test.js
@@ -102,4 +102,33 @@ describe("useVideoCollection (composite)", () => {
     expect(result.current.stats.progressiveVisible).toBe(80);
     expect(result.current.stats.activationTarget).toBe(80);
   });
+
+  it("threads hover audio orchestration state through collection API", () => {
+    const visibleVideos = new Set(["v1", "v2"]);
+    const loadedVideos = new Set(["v1", "v2"]);
+
+    const { result } = renderHook(() =>
+      useVideoCollection({
+        videos: makeVideos(2),
+        visibleVideos,
+        loadedVideos,
+        hoverAudioEnabled: true,
+      })
+    );
+
+    act(() => {
+      result.current.onCardHoverAudioStart("v1");
+    });
+    expect(result.current.activeHoverAudioId).toBe("v1");
+
+    act(() => {
+      result.current.onCardHoverAudioStart("v2");
+    });
+    expect(result.current.activeHoverAudioId).toBe("v2");
+
+    act(() => {
+      result.current.onCardHoverAudioEnd("v2");
+    });
+    expect(result.current.activeHoverAudioId).toBe(null);
+  });
 });


### PR DESCRIPTION
### Motivation
- Provide an opt-in UI toggle to make hovered video cards audible while preserving the existing preview/play model and orchestration layers.
- Keep audio coordination centralized in the play orchestrator layer and avoid pushing cross-card logic into App or individual cards.

### Description
- Add a `Hover audio` checkbox to the header and lift `hoverAudioEnabled` state to `App` so header controls drive the feature (`HeaderBar.jsx`, `App.jsx`).
- Thread `hoverAudioEnabled` through `useVideoCollection` into the play orchestrator so the collection layer owns orchestration (`useVideoCollection.js`, `usePlayOrchestrator.js`).
- Extend the play orchestrator with explicit hover-audio API and state: `activeHoverAudioId`, `onCardHoverAudioStart(videoId)`, `onCardHoverAudioEnd(videoId)` and ensure cleanup when hover-audio is disabled or the active card goes out of view (`usePlayOrchestrator.js`).
- Make `VideoCard` emit card-level hover enter/leave intents (on the card container), call `onHoverAudioStart`/`onHoverAudioEnd`, apply mute/unmute based on orchestrator-provided `isHoverAudioActive`, and stop participation on unmount; handle `NotAllowedError` autoplay rejection by falling back to muted playback without noisy UI errors (`VideoCard.jsx`).
- Pass necessary props from `App` -> `useVideoCollection` -> `VideoCard` (`hoverAudioEnabled`, `isHoverAudioActive`, `onHoverAudioStart`, `onHoverAudioEnd`).
- Tests: add/update unit tests around header toggle plumbing, orchestrator hover-audio transitions, collection passthrough, and VideoCard hover/audio behavior (`src/hooks/video-collection/*`, `src/components/VideoCard/__tests__/ui.test.jsx`, `src/App.test.jsx`).

### Testing
- Ran the targeted Vitest suite: `npm test -- src/hooks/video-collection/usePlayOrchestrator.test.js src/hooks/video-collection/useVideoCollection.test.js src/components/VideoCard/__tests__/ui.test.jsx src/App.test.jsx`.
- Result: All tests passed (Test Files: 4 passed; Tests: 27 passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c9c6ade7f8832ca017e53df8d8700c)