### PR TITLE
Restore Electron 43 Windows release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,10 @@ jobs:
         include:
           - os: ubuntu-latest
             artifact-name: linux
-          - os: windows-latest
+          # Electron 43 / better-sqlite3 currently requires a source rebuild on
+          # Windows. Pin VS 2022 until the dependency publishes ABI 148 assets;
+          # node-gyp 10 cannot discover the VS 18 image on windows-latest.
+          - os: windows-2022
             artifact-name: windows
 
     steps:
@@ -36,6 +39,8 @@ jobs:
           cache: "npm"
 
       - name: Install dependencies
+        env:
+          npm_config_msvs_version: ${{ runner.os == 'Windows' && '2022' || '' }}
         run: npm ci
 
       - name: Install Linux build dependencies

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "video-swarm",
-  "version": "0.6.0-rc.1",
+  "version": "0.6.0-rc.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "video-swarm",
-      "version": "0.6.0-rc.1",
+      "version": "0.6.0-rc.2",
       "hasInstallScript": true,
       "license": "GPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "video-swarm",
-  "version": "0.6.0-rc.1",
+  "version": "0.6.0-rc.2",
   "description": "Desktop application for viewing hundreds of videos simultaneously with advanced masonry layouts and real-time file system monitoring",
   "main": "main.js",
   "homepage": "https://github.com/Cerzi/videoswarm",

--- a/tests/electron/continue-review.smoke.spec.cjs
+++ b/tests/electron/continue-review.smoke.spec.cjs
@@ -101,7 +101,12 @@ test("continues a flushed review session after restart from the cached first gri
       '.video-item[data-filename="clip-0002.mp4"]'
     );
     await firstClip.click();
-    await firstPage.getByRole("button", { name: /^Accept\b/ }).click();
+    const selectionDetails = firstPage.getByRole("complementary", {
+      name: "Selection details",
+    });
+    await selectionDetails
+      .getByRole("button", { name: /^Accept\b/ })
+      .click();
 
     await expect
       .poll(() =>
@@ -121,7 +126,7 @@ test("continues a flushed review session after restart from the cached first gri
     // viewport sizes. Dismiss it through the user-facing control so this smoke
     // continues to exercise a real pointer selection rather than a forced DOM
     // click through an overlapping surface.
-    const closeSelectionDetails = firstPage.getByRole("button", {
+    const closeSelectionDetails = selectionDetails.getByRole("button", {
       name: "Close selection details",
     });
     await expect(closeSelectionDetails).toBeVisible();


### PR DESCRIPTION
## Summary

Restores Windows release packaging for Electron 43 and advances the release candidate to `0.6.0-rc.2`.

## Root cause

The `v0.6.0-rc.1` release workflow failed during Windows `npm ci`:

- `better-sqlite3@12.11.1` does not publish an Electron ABI 148 prebuilt binary, so Electron 43 requires a source rebuild.
- GitHub's current `windows-latest` image exposes Visual Studio 18.
- The bundled `node-gyp@10.2.0` cannot discover that Visual Studio generation and aborts before packaging.

The Linux matrix leg was then cancelled by the failed strategy job, so no draft release was created.

## Fix

- Pin the Windows release builder to `windows-2022`, whose Visual Studio 2022 toolchain is supported by node-gyp 10.
- Explicitly select MSVC 2022 for the native dependency rebuild.
- Advance package metadata to `0.6.0-rc.2`; the failed rc.1 tag remains immutable rather than being moved.

## Local validation

- [x] Release workflow YAML parses successfully
- [x] package/package-lock versions agree
- [x] zero-warning lint
- [x] `git diff --check`
- [x] Branch-dispatched Windows and Linux release builds
- [x] PR CI on the exact commit