### PR TITLE
Add v0.6 release-candidate feedback workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,150 @@
+name: Bug report
+description: Report a reproducible VideoSwarm problem or regression
+title: "[Bug]: "
+labels:
+  - bug
+  - needs triage
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve VideoSwarm. Please provide one problem per
+        report and remove private paths, filenames, prompts, or media before
+        attaching logs and screenshots.
+
+        Testing the v0.6 release candidate? Follow the
+        [RC feedback tracker](https://github.com/Cerzi/videoswarm/issues/80)
+        for the current build and test priorities.
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched the existing issues for this problem.
+          required: true
+        - label: I can reproduce this with the version reported below.
+          required: true
+        - label: I removed or obscured private media, prompts, and filesystem paths.
+          required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: VideoSwarm version
+      description: Copy the complete version, including any rc suffix.
+      placeholder: 0.6.0-rc.2
+    validations:
+      required: true
+
+  - type: dropdown
+    id: package
+    attributes:
+      label: Installation type
+      options:
+        - Windows installer
+        - Windows portable
+        - Linux AppImage
+        - Linux deb package
+        - Development checkout
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: operating_system
+    attributes:
+      label: Operating system
+      description: Include the Windows version or Linux distribution and version.
+      placeholder: Ubuntu 24.04 / Windows 11 24H2
+    validations:
+      required: true
+
+  - type: textarea
+    id: hardware
+    attributes:
+      label: Hardware
+      description: Include CPU, GPU, RAM, and display configuration when relevant.
+      placeholder: |
+        CPU:
+        GPU and driver:
+        RAM:
+        Displays / scaling:
+    validations:
+      required: true
+
+  - type: textarea
+    id: workload
+    attributes:
+      label: Media and folder workload
+      description: Include clip count, recursive folder shape, container/codec, resolution, and typical duration.
+      placeholder: 6,000 recursive MP4/H.264 clips, mostly 832x480 and 5 seconds long
+    validations:
+      required: true
+
+  - type: dropdown
+    id: playback_mode
+    attributes:
+      label: Playback mode
+      options:
+        - Balanced
+        - Adaptive Motion
+        - All Motion
+        - Static + Hover
+        - Not playback-related
+        - Unknown
+    validations:
+      required: true
+
+  - type: dropdown
+    id: regression
+    attributes:
+      label: Is this a regression?
+      description: A regression worked correctly in an earlier VideoSwarm release.
+      options:
+        - Yes
+        - No
+        - Not sure
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Start from application launch and include the smallest reliable sequence.
+      placeholder: |
+        1. Launch VideoSwarm.
+        2. Open...
+        3. Select...
+        4. Observe...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected result
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual result
+      description: Include frequency and whether restarting or changing modes affects it.
+    validations:
+      required: true
+
+  - type: textarea
+    id: diagnostics
+    attributes:
+      label: Diagnostics
+      description: Paste relevant renderer/main-process output after removing private data.
+      render: shell
+
+  - type: textarea
+    id: additional_context
+    attributes:
+      label: Additional context
+      description: Add safe screenshots, recordings, or anything else that helps reproduce the problem.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: v0.6 release-candidate feedback tracker
+    url: https://github.com/Cerzi/videoswarm/issues/80
+    about: Check the current RC, priority test areas, and stable-release gate.
+  - name: Download the current v0.6 release candidate
+    url: https://github.com/Cerzi/videoswarm/releases/tag/v0.6.0-rc.2
+    about: Install the Windows or Linux build and review checksums and known limitations.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,59 @@
+name: Feature request
+description: Propose a VideoSwarm workflow or capability
+title: "[Feature]: "
+labels:
+  - feature request
+  - needs triage
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Describe the review or browsing problem first. Concrete workflows help
+        us evaluate a feature without committing to one particular interface.
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched the existing issues for a similar request.
+          required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or workflow
+      description: What are you trying to accomplish, and what makes it difficult today?
+    validations:
+      required: true
+
+  - type: textarea
+    id: outcome
+    attributes:
+      label: Desired outcome
+      description: Describe the result you want, independent of a particular implementation.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Suggested interaction
+      description: Optional UI, shortcut, or workflow ideas.
+
+  - type: textarea
+    id: scale
+    attributes:
+      label: Typical workload
+      description: Include media type, folder size, review pattern, and platform when relevant.
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Current workaround or alternatives
+
+  - type: textarea
+    id: additional_context
+    attributes:
+      label: Additional context
+      description: Add mockups, examples, or links that clarify the request.

--- a/README.md
+++ b/README.md
@@ -166,6 +166,21 @@ Traditional file browsers show static thumbnails and provide limited ways to com
 
 ---
 
+## Test the v0.6 Release Candidate
+
+[Download v0.6.0-rc.2](https://github.com/Cerzi/videoswarm/releases/tag/v0.6.0-rc.2)
+for Windows or Linux, then follow the
+[RC feedback tracker](https://github.com/Cerzi/videoswarm/issues/80) for the
+priority test areas and stable-release gate. Close VideoSwarm before upgrading
+and back up irreplaceable profile data first.
+
+Please file each reproducible problem through the
+[structured bug-report form](https://github.com/Cerzi/videoswarm/issues/new?template=bug_report.yml&labels=rc%20feedback)
+so platform, workload, playback, and diagnostic details stay attached to the
+report. Feature ideas have a separate form in the issue chooser.
+
+---
+
 ## Roadmap
 
 Planned for upcoming versions:

--- a/docs/releases/v0.6.0.md
+++ b/docs/releases/v0.6.0.md
@@ -100,8 +100,12 @@ video clips.
 
 ## Release-candidate feedback
 
-Please include the operating system, CPU/GPU, folder size, codec/resolution,
-and playback mode when reporting a problem. Upgrade/profile retention, cold
-versus revisit loading, fullscreen audio teardown, embedded metadata discovery,
-and Copy Accepted collision/partial-result behavior are especially useful RC
-test areas.
+Follow the [v0.6 RC feedback tracker](https://github.com/Cerzi/videoswarm/issues/80)
+for priority test areas and the stable-release gate. File each reproducible
+problem through the [structured bug-report form](https://github.com/Cerzi/videoswarm/issues/new?template=bug_report.yml&labels=rc%20feedback)
+so the operating system, CPU/GPU, folder size, codec/resolution, playback mode,
+and diagnostics stay attached to the report.
+
+Upgrade/profile retention, cold versus revisit loading, fullscreen audio
+teardown, embedded metadata discovery, and Copy Accepted
+collision/partial-result behavior are especially useful RC test areas.


### PR DESCRIPTION
## Summary

Adds a structured GitHub feedback path for the v0.6 release-candidate soak.

## Changes

- Adds a privacy-aware bug-report issue form with version, package, platform, hardware, media workload, playback mode, regression, reproduction, expected/actual, and diagnostics fields.
- Adds a workflow-first feature-request form.
- Disables unstructured blank issues and links the issue chooser to the current RC and feedback tracker.
- Links README and checked-in v0.6 release notes to pinned tracker #80 and the structured bug form.
- Keeps individual bug reports separate from the tracker so they can be reproduced, labelled, and closed independently.

The repository-side setup is paired with fourteen new triage labels covering severity, regression/data-loss/performance, platform, functional area, and RC feedback.

## Validation

- [x] Parsed all issue-form YAML with js-yaml
- [x] Checked required fields, valid item types, and unique form IDs
- [x] `npm run lint`
- [x] `git diff --check`
- [x] GitHub Actions on the exact commit