### PR TITLE
Fix Linux rc.3 packaging with a sandboxed Debian release

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -33,7 +33,7 @@ body:
     attributes:
       label: VideoSwarm version
       description: Copy the complete version, including any rc suffix.
-      placeholder: 0.6.0-rc.2
+      placeholder: 0.6.0-rc.3
     validations:
       required: true
 
@@ -44,7 +44,6 @@ body:
       options:
         - Windows installer
         - Windows portable
-        - Linux AppImage
         - Linux deb package
         - Development checkout
         - Other

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,5 +4,5 @@ contact_links:
     url: https://github.com/Cerzi/videoswarm/issues/80
     about: Check the current RC, priority test areas, and stable-release gate.
   - name: Download the current v0.6 release candidate
-    url: https://github.com/Cerzi/videoswarm/releases/tag/v0.6.0-rc.2
-    about: Install the Windows or Linux build and review checksums and known limitations.
+    url: https://github.com/Cerzi/videoswarm/releases/tag/v0.6.0-rc.3
+    about: Install the Windows build or sandboxed Linux deb package and review checksums and known limitations.

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -17,12 +17,13 @@ template: |
     - `VideoSwarm-*-win-x64.exe`: Standard installer (recommended)
     - `VideoSwarm-*-win-x64-Portable.exe`: Portable build
   - **Linux**
-    - `VideoSwarm-*-linux.AppImage`: Portable image, mark executable and run
-    - `VideoSwarm-*-linux.deb`: Install with your package manager
+    - `VideoSwarm-*-linux.deb`: Install on Debian/Ubuntu with
+      `sudo apt install ./VideoSwarm-*-linux.deb`, then launch `video-swarm`;
+      the package configures Chromium's SUID sandbox helper
 
   ## Assets & checksums
   - The release workflow attaches the Windows installer/portable build and the
-    Linux AppImage/deb to a draft release.
+    Linux `.deb` to a draft release.
   - SHA256 checksums are included in the generated release notes.
 
   ## Notes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   test-build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout
@@ -42,7 +42,17 @@ jobs:
       - name: Install Electron smoke-test display
         run: |
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends xvfb
+          sudo apt-get install -y --no-install-recommends \
+            xvfb \
+            libasound2t64 \
+            libatk-bridge2.0-0 \
+            libcups2 \
+            libdrm2 \
+            libgbm1 \
+            libgtk-3-0 \
+            libnss3 \
+            libxkbcommon0 \
+            libxss1
 
       - name: Electron production smoke test
         run: xvfb-run -a npm run test:electron-smoke
@@ -59,3 +69,33 @@ jobs:
 
       - name: Electron pack (no installers)
         run: npm run electron:pack
+
+      - name: Build Debian package from packed app
+        run: >-
+          npx electron-builder --linux deb
+          --prepackaged dist/linux-unpacked --publish=never
+
+      - name: Install Debian package
+        shell: bash
+        run: |
+          set -euo pipefail
+          mapfile -t debs < <(find dist -maxdepth 1 -type f -name "VideoSwarm-*-linux.deb" | sort)
+          if [ "${#debs[@]}" -ne 1 ]; then
+            echo "Expected exactly one Linux .deb, found ${#debs[@]}"
+            exit 1
+          fi
+          if find dist -maxdepth 1 -type f -name "*.AppImage" | grep -q .; then
+            echo "AppImage output is forbidden by the Linux release policy"
+            exit 1
+          fi
+          dpkg-deb -f "${debs[0]}" Depends | grep -Eq '(^|, )libasound2(,|$)'
+          sudo apt-get install -y "./${debs[0]}"
+          test "$(stat -c '%U:%G %a' /opt/VideoSwarm/chrome-sandbox)" = "root:root 4755"
+
+      - name: Installed Debian package sandbox smoke test
+        run: >-
+          env -u VIDEOSWARM_DISABLE_SANDBOX
+          VIDEOSWARM_DEB_SMOKE=1
+          xvfb-run -a
+          npx playwright test tests/electron/deb-package.smoke.spec.cjs
+          --config=playwright.electron.config.cjs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-24.04
             artifact-name: linux
           # Electron 43 / better-sqlite3 currently requires a source rebuild on
           # Windows. Pin VS 2022 until the dependency publishes ABI 148 assets;
@@ -44,16 +44,71 @@ jobs:
         run: npm ci
 
       - name: Install Linux build dependencies
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.artifact-name == 'linux'
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
-            icnsutils graphicsmagick xz-utils libarchive-tools
+            icnsutils \
+            graphicsmagick \
+            libarchive-tools \
+            libasound2t64 \
+            libatk-bridge2.0-0 \
+            libcups2 \
+            libdrm2 \
+            libgbm1 \
+            libgtk-3-0 \
+            libnss3 \
+            libxkbcommon0 \
+            libxss1 \
+            xvfb \
+            xz-utils
 
-      - name: Build application
+      - name: Build Linux Debian package
+        if: matrix.artifact-name == 'linux'
+        env:
+          CSC_IDENTITY_AUTO_DISCOVERY: "false"
+        run: |
+          npm run vite:build
+          npx electron-builder --linux deb --publish=never
+
+      - name: Build Windows application
+        if: matrix.artifact-name == 'windows'
         env:
           CSC_IDENTITY_AUTO_DISCOVERY: "false"
         run: npm run electron:dist
+
+      - name: Install and smoke-test Linux Debian package
+        if: matrix.artifact-name == 'linux'
+        shell: bash
+        run: |
+          set -euo pipefail
+          mapfile -t debs < <(find dist -maxdepth 1 -type f -name "VideoSwarm-*-linux.deb" | sort)
+          if [ "${#debs[@]}" -ne 1 ]; then
+            echo "Expected exactly one Linux .deb, found ${#debs[@]}"
+            exit 1
+          fi
+          if find dist -maxdepth 1 -type f -name "*.AppImage" | grep -q .; then
+            echo "AppImage output is forbidden by the Linux release policy"
+            exit 1
+          fi
+          dpkg-deb -f "${debs[0]}" Depends | grep -Eq '(^|, )libasound2(,|$)'
+          sudo apt-get install -y "./${debs[0]}"
+          test "$(stat -c '%U:%G %a' /opt/VideoSwarm/chrome-sandbox)" = "root:root 4755"
+          env -u VIDEOSWARM_DISABLE_SANDBOX \
+            VIDEOSWARM_DEB_SMOKE=1 \
+            xvfb-run -a \
+            npx playwright test tests/electron/deb-package.smoke.spec.cjs \
+              --config=playwright.electron.config.cjs
+
+      - name: Upload Linux package smoke diagnostics
+        if: failure() && matrix.artifact-name == 'linux'
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-deb-smoke-diagnostics
+          path: |
+            playwright-report/
+            test-results/
+          if-no-files-found: ignore
 
       - name: Prepare artifacts
         shell: bash
@@ -61,13 +116,20 @@ jobs:
           set -euo pipefail
           mkdir -p release-assets
 
-          if [ "${{ matrix.os }}" = "ubuntu-latest" ]; then
-            find dist -maxdepth 1 -type f -name "VideoSwarm-*-linux.AppImage" -exec cp {} release-assets/ \;
-            find dist -maxdepth 1 -type f \( -name "VideoSwarm-*-linux.deb" -o -name "VideoSwarm_*_amd64.deb" \) -exec cp {} release-assets/ \;
+          if [ "${{ matrix.artifact-name }}" = "linux" ]; then
+            mapfile -t assets < <(find dist -maxdepth 1 -type f -name "VideoSwarm-*-linux.deb" | sort)
+            if [ "${#assets[@]}" -ne 1 ]; then
+              echo "Expected exactly one Linux release asset, found ${#assets[@]}"
+              exit 1
+            fi
           else
-            find dist -maxdepth 1 -type f -name "VideoSwarm-*-win-x64.exe" -exec cp {} release-assets/ \;
-            find dist -maxdepth 1 -type f -name "VideoSwarm-*-win-x64-Portable.exe" -exec cp {} release-assets/ \;
+            mapfile -t assets < <(find dist -maxdepth 1 -type f -name "VideoSwarm-*-win-x64*.exe" | sort)
+            if [ "${#assets[@]}" -ne 2 ]; then
+              echo "Expected exactly two Windows release assets, found ${#assets[@]}"
+              exit 1
+            fi
           fi
+          cp "${assets[@]}" release-assets/
 
       - name: List artifacts
         shell: bash
@@ -103,17 +165,21 @@ jobs:
 
           mkdir -p release-files
 
-          find all-artifacts -maxdepth 3 -type f -name "VideoSwarm-*-linux.AppImage" -exec cp {} release-files/ \;
-          find all-artifacts -maxdepth 3 -type f \( -name "VideoSwarm-*-linux.deb" -o -name "VideoSwarm_*_amd64.deb" \) -exec cp {} release-files/ \;
-          find all-artifacts -maxdepth 3 -type f -name "VideoSwarm-*-win-x64.exe" -exec cp {} release-files/ \;
-          find all-artifacts -maxdepth 3 -type f -name "VideoSwarm-*-win-x64-Portable.exe" -exec cp {} release-files/ \;
+          mapfile -t linux_assets < <(find all-artifacts -maxdepth 3 -type f -name "VideoSwarm-*-linux.deb" | sort)
+          mapfile -t windows_assets < <(find all-artifacts -maxdepth 3 -type f -name "VideoSwarm-*-win-x64*.exe" | sort)
+          if [ "${#linux_assets[@]}" -ne 1 ] || [ "${#windows_assets[@]}" -ne 2 ]; then
+            echo "Expected one Linux .deb and two Windows executables"
+            echo "Found ${#linux_assets[@]} Linux and ${#windows_assets[@]} Windows assets"
+            exit 1
+          fi
+          cp "${linux_assets[@]}" "${windows_assets[@]}" release-files/
 
           echo "Final release files:"
           ls -la release-files/
 
           FILE_COUNT=$(find release-files -type f | wc -l)
-          if [ "$FILE_COUNT" -ne 4 ]; then
-            echo "Expected 4 release files, found $FILE_COUNT"
+          if [ "$FILE_COUNT" -ne 3 ]; then
+            echo "Expected 3 release files, found $FILE_COUNT"
             exit 1
           fi
 
@@ -153,7 +219,6 @@ jobs:
             - \`VideoSwarm-*-win-x64-Portable.exe\`: Portable build (no installation)
           - **Linux**
             - \`VideoSwarm-*-linux.deb\`: Install with your package manager
-            - \`VideoSwarm-*-linux.AppImage\`: Make executable and run directly
 
           ## Checksums (SHA256)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,8 +30,8 @@ Node.js `>=22.12.0` is required. Electron 43 requires this, and native modules m
   `npm run dev`
 - If a Linux development host cannot provide Chromium's sandbox, use the
   explicit development-only fallback `npm run electron:dev:no-sandbox` or
-  `npm run dev:no-sandbox`; normal source and packaged launches remain
-  sandboxed.
+  `npm run dev:no-sandbox`; normal source launches and installed `.deb`
+  releases remain sandboxed.
 - Run the renderer dev server only:
   `npm run vite:dev`
 - Build the renderer only:
@@ -77,7 +77,9 @@ Expected current test behavior: the suite passes, but some tests print known Rea
 - `src/app/hooks/`: app-level hooks for Electron folder lifecycle, filters, masonry layout, metadata actions, and zoom controls.
 - `src/services/thumbService.js`: renderer thumbnail capture/cache coordination for drag thumbnails.
 - `src/config/`: feature flags and support/donation content.
-- `scripts/linux-fix.js`: electron-builder Linux wrapper that preserves Chromium sandboxing by default and supports an explicit warned compatibility opt-out.
+- `scripts/linux-fix.js`: electron-builder Linux packaging support that keeps
+  Chromium sandboxing enabled. The supported Linux release is the installed
+  `.deb`, whose package lifecycle configures the bundled SUID sandbox helper.
 - `dist-react/`, `dist/`, `coverage/`, and `node_modules/` are generated and should not be edited by hand.
 
 ## Architecture Notes
@@ -114,7 +116,13 @@ Expected current test behavior: the suite passes, but some tests print known Rea
 
 - Linux is a priority platform, but NVIDIA hardware video decoding is not currently assumed to work in Electron/Chromium. Avoid promising GPU video decode support without fresh verification on target hardware.
 - Current Linux startup flags in `main.js` use EGL/ANGLE/OpenGL-related Chromium switches and ignore the GPU blocklist. These affect compositing/GL behavior, not guaranteed hardware video decode.
-- Packaged Linux launches keep Chromium sandboxing enabled by default. `VIDEOSWARM_DISABLE_SANDBOX=1` is an explicit warned compatibility escape hatch, not an acceptable release default or test assumption.
+- Linux releases are Debian/Ubuntu x64 `.deb` packages. Their post-installation
+  hook must leave the bundled `chrome-sandbox` owned by root with mode `4755`;
+  do not publish a Linux artifact whose normal launch requires `--no-sandbox`.
+- Portable AppImages are unsupported because their temporary mount cannot
+  reliably provide that SUID helper configuration on hardened Ubuntu. The
+  explicit `*:no-sandbox` commands are development-only escape hatches, not
+  acceptable release defaults or package smoke assumptions.
 
 ## Coding Conventions
 

--- a/README.md
+++ b/README.md
@@ -161,15 +161,16 @@ Traditional file browsers show static thumbnails and provide limited ways to com
 - The app is designed primarily for many short clips. Long, high-resolution,
   or uncapped workloads remain hardware-sensitive even though 1,000- and
   6,000-item library gates are covered.
-- Release artifacts currently target Windows x64 and Linux; there is no macOS,
-  mobile, or web release.
+- Release artifacts currently target Windows x64 and Debian/Ubuntu x64. Linux
+  releases are `.deb`-only; there is no portable Linux, macOS, mobile, or web
+  release.
 
 ---
 
 ## Test the v0.6 Release Candidate
 
-[Download v0.6.0-rc.2](https://github.com/Cerzi/videoswarm/releases/tag/v0.6.0-rc.2)
-for Windows or Linux, then follow the
+[Download v0.6.0-rc.3](https://github.com/Cerzi/videoswarm/releases/tag/v0.6.0-rc.3)
+for Windows, or install its `.deb` on Debian/Ubuntu, then follow the
 [RC feedback tracker](https://github.com/Cerzi/videoswarm/issues/80) for the
 priority test areas and stable-release gate. Close VideoSwarm before upgrading
 and back up irreplaceable profile data first.
@@ -194,6 +195,27 @@ Planned for upcoming versions:
 ---
 
 ## Installation & Development
+
+### Linux release installation
+
+Video Swarm's supported Linux release is the Debian/Ubuntu x64 `.deb`. Download
+it from the [latest release](https://github.com/Cerzi/videoswarm/releases), then
+install and launch it with:
+
+```bash
+sudo apt install ./VideoSwarm-*-linux.deb
+video-swarm
+```
+
+The package's post-installation hook gives the bundled Chromium
+`chrome-sandbox` helper root ownership and mode `4755`, so the application can
+retain its operating-system sandbox.
+
+Portable AppImages are not published. Their temporary FUSE mount cannot
+reliably preserve the helper's required root ownership and setuid mode, while
+hardened Ubuntu installations may also block Chromium's unprivileged-user-
+namespace fallback. Video Swarm does not silently disable the production
+sandbox to work around that packaging conflict.
 
 ### Prerequisites
 - **Node.js 22.12.0 or later**
@@ -223,7 +245,8 @@ npm run electron:build   # packaged app for current platform
 
 ### Other build targets:
 - `electron:dist` – build without publishing
-- `electron:pack` – portable package
+- `electron:pack` – unpacked application directory for development/package
+  smoke testing, not a portable release artifact
 
 ### Project Structure
 ```css

--- a/docs/architecture/large-library-performance.md
+++ b/docs/architecture/large-library-performance.md
@@ -678,12 +678,15 @@ macOS activation, and second-instance restoration share one window-creation
 single flight; fatal startup failure releases the invisible primary rather than
 leaving the lock-owning process headless.
 
-The packaged Linux launcher no longer disables Chromium's OS sandbox by
-default. A user can explicitly set `VIDEOSWARM_DISABLE_SANDBOX=1` as a
-diagnostic compatibility escape hatch, which emits a warning and must not be
-treated as the production security baseline. Development and CI launchers may
-still opt out where their container forbids user namespaces; the packaged
-default is the acceptance surface here.
+The supported Linux release is now the installed Debian/Ubuntu x64 `.deb`.
+Its package lifecycle gives the bundled Chromium `chrome-sandbox` helper root
+ownership and mode `4755`, and the production launcher does not disable the OS
+sandbox. Portable AppImages are not a supported release surface: their
+temporary FUSE mount cannot reliably retain the helper's root/setuid
+configuration, and hardened Ubuntu may also deny Chromium's unprivileged user
+namespace fallback. Development and CI launchers may still explicitly opt out
+where their container forbids both sandbox mechanisms; that escape hatch is
+never a release default or packaged acceptance surface.
 
 Acceptance criteria:
 
@@ -740,7 +743,7 @@ updates, catalog recovery/profile isolation, and shutdown ownership.
 | Electron smoke and performance soak harnesses | **Implemented** | Production Electron lifecycle smoke is CI-gated under Xvfb; the local Linux runner emits measured plateau/slope and baseline-relative diagnostics with optional traces and heap snapshots. |
 | Electron-ABI SQLite test job | **Implemented** | Coverage and focused native suites run through Electron's Node runtime with an environment gate that converts ABI load failures into test failures rather than skips. |
 | Node, lint, coverage, and build CI gates | **Implemented** | Node 22.12 repository/workflow pins, zero-warning ESLint, cleaned ratcheted coverage, explicit Vite build, Electron smoke, and unpacked packaging are mandatory. |
-| Production Electron boundary hardening | **Implemented** | Sandboxed, web-secure windows now use opaque range-capable media URLs, one trusted and bounded IPC registrar, profile/owner-scoped path grants, confirmation-bound trash, atomic/bounded settings and profile catalogs, single-instance ownership, denied popup/navigation/permissions, and coordinated native shutdown/relaunch. |
+| Production Electron boundary hardening | **Implemented** | Sandboxed, web-secure windows now use opaque range-capable media URLs, one trusted and bounded IPC registrar, profile/owner-scoped path grants, confirmation-bound trash, atomic/bounded settings and profile catalogs, single-instance ownership, denied popup/navigation/permissions, coordinated native shutdown/relaunch, and a `.deb` lifecycle that configures Chromium's SUID sandbox helper. |
 
 ## Production boundary and deferred-work implementation slice
 
@@ -754,11 +757,12 @@ updates, catalog recovery/profile isolation, and shutdown ownership.
    cache signatures and reject canonical proxy paths that escape the
    profile-local cache, including through a replaced symlink.
 3. **Implemented** — Enable production `webSecurity`, renderer sandbox
-   preferences, context isolation, and a secure-by-default packaged Linux
-   launcher; deny popups, webviews, unexpected navigation, redirects, and
-   permission requests. Production CSP removes Vite's localhost WebSocket
-   sources, while the development HTML transform adds only those local HMR
-   endpoints.
+   preferences, context isolation, and a secure-by-default installed Linux
+   `.deb`; deny popups, webviews, unexpected navigation, redirects, and
+   permission requests. The `.deb` lifecycle configures the root-owned,
+   mode-`4755` Chromium helper. Production CSP removes Vite's localhost
+   WebSocket sources, while the development HTML transform adds only those
+   local HMR endpoints.
 4. **Implemented** — Put every static inbound IPC handler behind live-window,
    main-frame, exact-origin trust and a default payload-size ceiling. Add
    channel-specific shape/count/string bounds and dispose registrations with
@@ -1281,16 +1285,17 @@ their stated evidence exists:
   deferred. Copy Accepted—including optional exact sidecars, collision
   preflight, exclusive no-overwrite writes, and bounded progress/cancellation—
   is implemented; see [`review-workflow.md`](review-workflow.md).
-- **Cross-platform packaged validation:** Linux production smoke now exercises
-  the security boundary and custom media ranges. Windows and macOS packaged
-  runs should be added when runners are available, particularly for custom
-  protocol playback, atomic replacement semantics, native trash/shell actions,
-  macOS activation, and shutdown/relaunch behavior. Add a true two-process
-  single-instance smoke rather than relying only on focused lifecycle wiring
-  coverage. A real-host Linux launch should also verify the secure-by-default
-  package on distributions with supported user namespaces; the automated
-  container smoke intentionally opts out of the OS sandbox. This is a
-  validation gap, not a known application-boundary defect.
+- **Cross-platform packaged validation:** Linux source-production smoke
+  exercises the security boundary and custom media ranges. In addition, CI and
+  the release workflow install the generated Debian package, assert that
+  `chrome-sandbox` is root-owned with mode `4755`, and launch the installed
+  `/usr/bin/video-swarm` command without either sandbox-disable switch before
+  accepting the artifact. Windows and macOS packaged runs should be added when
+  runners are available, particularly for
+  custom protocol playback, atomic replacement semantics, native trash/shell
+  actions, macOS activation, and shutdown/relaunch behavior. Add a true
+  two-process single-instance smoke rather than relying only on focused
+  lifecycle wiring coverage.
 - **Descriptor-level filesystem race hardening:** canonical root validation
   rejects existing symlink escapes, but an external process can still replace
   a validated path between validation and some path-based shell/media/native

--- a/docs/releases/v0.6.0.md
+++ b/docs/releases/v0.6.0.md
@@ -73,6 +73,11 @@ video clips.
 - Close VideoSwarm before upgrading. Because this is a large pre-1.0 storage
   and lifecycle update, release-candidate testers should back up irreplaceable
   application profile data first.
+- Linux release candidates are distributed as Debian/Ubuntu x64 `.deb`
+  packages only. Installing the package configures the bundled Chromium SUID
+  sandbox helper with root ownership and mode `4755`; no production
+  `--no-sandbox` fallback is used. Install the downloaded artifact with
+  `sudo apt install ./VideoSwarm-*-linux.deb`, then launch `video-swarm`.
 - Profile database evolution is additive and transactional. Existing tags,
   ratings, and review decisions are preserved.
 - Existing rated-but-Unreviewed content is promoted to **Reviewed** to enforce
@@ -95,8 +100,11 @@ video clips.
 - Copy Accepted is copy-only and does not transfer VideoSwarm metadata. Move
   Accepted remains deferred, and Reject processing is limited to 2,000 local
   files per scoped batch.
-- Release artifacts currently target Windows x64 and Linux. Windows builds are
-  unsigned, and there is no macOS, mobile, or web release.
+- Release artifacts currently target Windows x64 and Debian/Ubuntu x64.
+  Windows builds are unsigned. The Linux release is `.deb`-only because a
+  portable AppImage cannot reliably preserve Chromium's required SUID sandbox
+  helper configuration on hardened Ubuntu. There is no other portable Linux,
+  macOS, mobile, or web release.
 
 ## Release-candidate feedback
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "video-swarm",
-  "version": "0.6.0-rc.2",
+  "version": "0.6.0-rc.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "video-swarm",
-      "version": "0.6.0-rc.2",
+      "version": "0.6.0-rc.3",
       "hasInstallScript": true,
       "license": "GPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "video-swarm",
-  "version": "0.6.0-rc.2",
+  "version": "0.6.0-rc.3",
   "description": "Desktop application for viewing hundreds of videos simultaneously with advanced masonry layouts and real-time file system monitoring",
   "main": "main.js",
   "homepage": "https://github.com/Cerzi/videoswarm",
@@ -139,7 +139,6 @@
     },
     "linux": {
       "target": [
-        "AppImage",
         "deb"
       ],
       "artifactName": "VideoSwarm-${version}-linux.${ext}",
@@ -152,6 +151,12 @@
         "Categories": "Video;"
       },
       "maintainer": "Cerzi <bpateman@gmail.com>"
+    },
+    "deb": {
+      "afterInstall": "scripts/deb-after-install.tpl",
+      "fpm": [
+        "--depends=libasound2"
+      ]
     },
     "nsis": {
       "oneClick": false,

--- a/scripts/deb-after-install.tpl
+++ b/scripts/deb-after-install.tpl
@@ -1,0 +1,46 @@
+#!/bin/bash
+set -e
+
+executable='${executable}'
+install_path='/opt/${sanitizedProductName}/${executable}'
+sandbox_path='/opt/${sanitizedProductName}/chrome-sandbox'
+
+# Chromium's SUID sandbox is the supported sandbox on hardened Ubuntu hosts.
+# Do not expose an installed command unless the helper is a real packaged file
+# with the exact ownership and mode Chromium requires.
+if [ ! -f "$sandbox_path" ] || [ -L "$sandbox_path" ]; then
+    echo "Video Swarm installation failed: Chromium sandbox helper is missing or invalid: $sandbox_path" >&2
+    exit 1
+fi
+
+chown root:root -- "$sandbox_path"
+chmod 4755 -- "$sandbox_path"
+
+sandbox_state="$(stat -c '%u:%g:%a' -- "$sandbox_path")"
+if [ "$sandbox_state" != '0:0:4755' ]; then
+    echo "Video Swarm installation failed: Chromium sandbox helper has $sandbox_state; expected 0:0:4755" >&2
+    exit 1
+fi
+
+if command -v update-alternatives >/dev/null 2>&1; then
+    # Remove a legacy direct link before registering the packaged launcher.
+    if [ -L "/usr/bin/$executable" ] && \
+       [ -e "/usr/bin/$executable" ] && \
+       [ "$(readlink "/usr/bin/$executable")" != "/etc/alternatives/$executable" ]; then
+        rm -f "/usr/bin/$executable"
+    fi
+
+    update-alternatives \
+        --install "/usr/bin/$executable" "$executable" "$install_path" 100 || \
+        ln -sf "$install_path" "/usr/bin/$executable"
+else
+    ln -sf "$install_path" "/usr/bin/$executable"
+fi
+
+if command -v update-mime-database >/dev/null 2>&1; then
+    update-mime-database /usr/share/mime || true
+fi
+
+if command -v update-desktop-database >/dev/null 2>&1; then
+    update-desktop-database /usr/share/applications || true
+fi

--- a/scripts/linux-fix.js
+++ b/scripts/linux-fix.js
@@ -1,24 +1,24 @@
 const fs = require('fs');
 const path = require('path');
 
-exports.default = async function(context) {
-  console.log('Installing Linux launcher wrapper...');
-  
-  if (context.electronPlatformName === 'linux') {
-    const appOutDir = context.appOutDir;
-    const executableName = 'video-swarm'; // Match the executableName in package.json
-    const executablePath = path.join(appOutDir, executableName);
-    
-    console.log('Installing secure launcher at:', executablePath);
-    
-    // Rename original executable
-    fs.renameSync(executablePath, executablePath + '-bin');
-    
-    // Create wrapper script
-    const wrapperScript = `#!/bin/bash
+const EXECUTABLE_NAME = 'video-swarm';
+
+function createDebianLauncherScript(executableName = EXECUTABLE_NAME) {
+  return `#!/bin/bash
 set -e
 
-launcher_dir="$(cd "$(dirname "$0")" && pwd)"
+# Resolve the installed /usr/bin symlink before looking for the packaged
+# executable. Debian packages place the application itself under /opt.
+launcher_path="${'${BASH_SOURCE[0]}'}"
+while [[ -L "$launcher_path" ]]; do
+  launcher_dir="$(cd -P "$(dirname "$launcher_path")" >/dev/null 2>&1 && pwd)"
+  launcher_path="$(readlink "$launcher_path")"
+  if [[ "$launcher_path" != /* ]]; then
+    launcher_path="$launcher_dir/$launcher_path"
+  fi
+done
+launcher_dir="$(cd -P "$(dirname "$launcher_path")" >/dev/null 2>&1 && pwd)"
+
 sandbox_args=()
 if [[ "${'${VIDEOSWARM_DISABLE_SANDBOX:-0}'}" == "1" ]]; then
   echo "Video Swarm warning: Chromium OS sandbox disabled by VIDEOSWARM_DISABLE_SANDBOX=1" >&2
@@ -27,10 +27,21 @@ fi
 
 exec "$launcher_dir/${executableName}-bin" "${'${sandbox_args[@]}'}" "$@"
 `;
-    
-    fs.writeFileSync(executablePath, wrapperScript);
+}
+
+exports.default = async function(context) {
+  if (context.electronPlatformName === 'linux') {
+    const appOutDir = context.appOutDir;
+    const executablePath = path.join(appOutDir, EXECUTABLE_NAME);
+
+    console.log('Installing sandbox-preserving Debian launcher at:', executablePath);
+
+    fs.renameSync(executablePath, executablePath + '-bin');
+    fs.writeFileSync(executablePath, createDebianLauncherScript());
     fs.chmodSync(executablePath, 0o755);
-    
-    console.log('Linux launcher installed with sandboxing enabled by default');
+
+    console.log('Debian launcher installed with sandboxing enabled by default');
   }
 };
+
+exports.createDebianLauncherScript = createDebianLauncherScript;

--- a/scripts/linux-fix.test.js
+++ b/scripts/linux-fix.test.js
@@ -2,12 +2,17 @@
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
+import { spawnSync } from 'child_process';
 import { afterEach, describe, expect, it } from 'vitest';
 import { createRequire } from 'module';
 
 const require = createRequire(import.meta.url);
 const linuxFix = require('./linux-fix.js').default;
 const temporaryDirectories = new Set();
+const debianAfterInstall = fs.readFileSync(
+  path.join(process.cwd(), 'scripts', 'deb-after-install.tpl'),
+  'utf8',
+);
 
 afterEach(() => {
   for (const directory of temporaryDirectories) {
@@ -16,8 +21,81 @@ afterEach(() => {
   temporaryDirectories.clear();
 });
 
-describe('packaged Linux launcher', () => {
-  it('keeps the Chromium sandbox on unless the user explicitly opts out', async () => {
+function installTestLauncher() {
+  const appOutDir = fs.mkdtempSync(path.join(os.tmpdir(), 'videoswarm-deb-'));
+  temporaryDirectories.add(appOutDir);
+  const executablePath = path.join(appOutDir, 'video-swarm');
+  fs.writeFileSync(executablePath, '#!/bin/bash\nprintf \'%s\\0\' "$@"\n');
+  fs.chmodSync(executablePath, 0o755);
+  return { appOutDir, executablePath };
+}
+
+function runLauncher(executablePath, args, environment = {}) {
+  const childEnvironment = { ...process.env, ...environment };
+  if (!Object.hasOwn(environment, 'VIDEOSWARM_DISABLE_SANDBOX')) {
+    delete childEnvironment.VIDEOSWARM_DISABLE_SANDBOX;
+  }
+
+  const result = spawnSync(executablePath, args, {
+    encoding: 'buffer',
+    env: childEnvironment,
+  });
+
+  return {
+    ...result,
+    args: result.stdout.toString().split('\0').filter(Boolean),
+    stderrText: result.stderr.toString(),
+  };
+}
+
+describe('packaged Debian launcher', () => {
+  it('runs the packaged executable with sandboxing on by default', async () => {
+    const { appOutDir, executablePath } = installTestLauncher();
+
+    await linuxFix({ electronPlatformName: 'linux', appOutDir });
+
+    const result = runLauncher(executablePath, ['--example', 'two words']);
+    expect(result.status).toBe(0);
+    expect(result.args).toEqual(['--example', 'two words']);
+    expect(result.stderrText).toBe('');
+    expect(fs.existsSync(`${executablePath}-bin`)).toBe(true);
+    expect(fs.statSync(executablePath).mode & 0o777).toBe(0o755);
+  });
+
+  it('only disables the sandbox through the explicit compatibility escape hatch', async () => {
+    const { appOutDir, executablePath } = installTestLauncher();
+
+    await linuxFix({ electronPlatformName: 'linux', appOutDir });
+
+    const result = runLauncher(
+      executablePath,
+      ['--example'],
+      { VIDEOSWARM_DISABLE_SANDBOX: '1' },
+    );
+    expect(result.status).toBe(0);
+    expect(result.args).toEqual([
+      '--no-sandbox',
+      '--disable-setuid-sandbox',
+      '--example',
+    ]);
+    expect(result.stderrText).toContain('Chromium OS sandbox disabled');
+  });
+
+  it('resolves the symlink used by an installed Debian command', async () => {
+    const { appOutDir, executablePath } = installTestLauncher();
+    const commandDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'videoswarm-bin-'));
+    temporaryDirectories.add(commandDirectory);
+    const installedCommand = path.join(commandDirectory, 'video-swarm');
+
+    await linuxFix({ electronPlatformName: 'linux', appOutDir });
+    fs.symlinkSync(path.relative(commandDirectory, executablePath), installedCommand);
+
+    const result = runLauncher(installedCommand, ['--from-deb-command']);
+    expect(result.status).toBe(0);
+    expect(result.args).toEqual(['--from-deb-command']);
+  });
+
+  it('writes a launcher that documents the opt-in compatibility path', async () => {
     const appOutDir = fs.mkdtempSync(path.join(os.tmpdir(), 'videoswarm-pack-'));
     temporaryDirectories.add(appOutDir);
     const executablePath = path.join(appOutDir, 'video-swarm');
@@ -30,8 +108,7 @@ describe('packaged Linux launcher', () => {
     expect(wrapper).toContain('VIDEOSWARM_DISABLE_SANDBOX');
     expect(wrapper).toContain('sandbox_args+=(--no-sandbox --disable-setuid-sandbox)');
     expect(wrapper).toContain('"${sandbox_args[@]}"');
-    expect(fs.existsSync(`${executablePath}-bin`)).toBe(true);
-    expect(fs.statSync(executablePath).mode & 0o777).toBe(0o755);
+    expect(wrapper).toContain('while [[ -L "$launcher_path" ]]');
   });
 
   it('leaves non-Linux packages unchanged', async () => {
@@ -44,5 +121,43 @@ describe('packaged Linux launcher', () => {
 
     expect(fs.readFileSync(executablePath, 'utf8')).toBe('original');
     expect(fs.existsSync(`${executablePath}-bin`)).toBe(false);
+  });
+});
+
+describe('Debian post-install sandbox contract', () => {
+  it('configures the installed Chromium helper as root-owned SUID', () => {
+    expect(debianAfterInstall).toContain('set -e');
+    expect(debianAfterInstall).toContain('chown root:root -- "$sandbox_path"');
+    expect(debianAfterInstall).toContain('chmod 4755 -- "$sandbox_path"');
+    expect(debianAfterInstall).toContain("!= '0:0:4755'");
+    expect(debianAfterInstall).not.toMatch(
+      /(?:chown root:root|chmod 4755)[^\n]*\|\| true/,
+    );
+  });
+
+  it('preserves command registration and desktop database refreshes', () => {
+    expect(debianAfterInstall).toContain('update-alternatives');
+    expect(debianAfterInstall).toContain('update-mime-database');
+    expect(debianAfterInstall).toContain('update-desktop-database');
+  });
+
+  it('uses only supported builder macros and renders as valid Bash', () => {
+    const macros = Array.from(
+      debianAfterInstall.matchAll(/\$\{([a-zA-Z]+)\}/g),
+      (match) => match[1],
+    );
+    expect(new Set(macros)).toEqual(
+      new Set(['executable', 'sanitizedProductName']),
+    );
+
+    const renderedScript = debianAfterInstall
+      .replaceAll('${executable}', 'video-swarm')
+      .replaceAll('${sanitizedProductName}', 'VideoSwarm');
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'videoswarm-postinst-'));
+    temporaryDirectories.add(directory);
+    const scriptPath = path.join(directory, 'postinst');
+    fs.writeFileSync(scriptPath, renderedScript);
+
+    expect(spawnSync('bash', ['-n', scriptPath]).status).toBe(0);
   });
 });

--- a/tests/electron/deb-package.smoke.spec.cjs
+++ b/tests/electron/deb-package.smoke.spec.cjs
@@ -1,0 +1,109 @@
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { _electron: electron, expect, test } = require("@playwright/test");
+
+const installedExecutable = "/usr/bin/video-swarm";
+const sandboxHelper = "/opt/VideoSwarm/chrome-sandbox";
+
+test.describe("installed Linux Debian package", () => {
+  test.skip(
+    process.platform !== "linux" || process.env.VIDEOSWARM_DEB_SMOKE !== "1",
+    "Only runs after CI installs the release .deb"
+  );
+
+  test("starts the packaged app with its Chromium sandbox enabled", async () => {
+    expect(process.getuid()).not.toBe(0);
+    expect(fs.existsSync(installedExecutable)).toBe(true);
+    expect(fs.existsSync(sandboxHelper)).toBe(true);
+    expect(fs.realpathSync(installedExecutable)).toBe(
+      "/opt/VideoSwarm/video-swarm"
+    );
+
+    const sandboxStat = fs.statSync(sandboxHelper);
+    expect(sandboxStat.uid).toBe(0);
+    expect(sandboxStat.gid).toBe(0);
+    expect(sandboxStat.mode & 0o7777).toBe(0o4755);
+
+    const tempRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), "videoswarm-deb-smoke-")
+    );
+    const homeDir = path.join(tempRoot, "home");
+    const configDir = path.join(tempRoot, "config");
+    const cacheDir = path.join(tempRoot, "cache");
+    const dataDir = path.join(tempRoot, "data");
+    const stateDir = path.join(tempRoot, "state");
+    const runtimeDir = path.join(tempRoot, "runtime");
+    for (const directory of [
+      homeDir,
+      configDir,
+      cacheDir,
+      dataDir,
+      stateDir,
+      runtimeDir,
+    ]) {
+      fs.mkdirSync(directory, { recursive: true });
+    }
+    fs.chmodSync(runtimeDir, 0o700);
+
+    const env = {
+      ...process.env,
+      HOME: homeDir,
+      USERPROFILE: homeDir,
+      XDG_CACHE_HOME: cacheDir,
+      XDG_CONFIG_HOME: configDir,
+      XDG_DATA_HOME: dataDir,
+      XDG_STATE_HOME: stateDir,
+      XDG_RUNTIME_DIR: runtimeDir,
+    };
+    delete env.ELECTRON_RUN_AS_NODE;
+    delete env.VIDEOSWARM_DISABLE_SANDBOX;
+
+    let electronApp;
+    try {
+      electronApp = await electron.launch({
+        executablePath: installedExecutable,
+        chromiumSandbox: true,
+        cwd: homeDir,
+        env,
+        timeout: 30_000,
+      });
+
+      const page = await electronApp.firstWindow();
+      await page.waitForLoadState("domcontentloaded");
+      await expect(page).toHaveTitle(/Video Swarm/);
+      await expect(
+        page.locator(".app").getByText("Welcome to Video Swarm")
+      ).toBeVisible();
+
+      const runtime = await electronApp.evaluate(({ app }) => ({
+        isPackaged: app.isPackaged,
+        noSandbox: app.commandLine.hasSwitch("no-sandbox"),
+        disableSetuidSandbox: app.commandLine.hasSwitch(
+          "disable-setuid-sandbox"
+        ),
+        argv: process.argv,
+        execPath: process.execPath,
+      }));
+
+      expect(runtime.isPackaged).toBe(true);
+      expect(runtime.noSandbox).toBe(false);
+      expect(runtime.disableSetuidSandbox).toBe(false);
+      expect(runtime.argv).not.toContain("--no-sandbox");
+      expect(runtime.argv).not.toContain("--disable-setuid-sandbox");
+      expect(runtime.execPath).toBe("/opt/VideoSwarm/video-swarm-bin");
+      await expect
+        .poll(() =>
+          page.evaluate(() => ({
+            isElectron: window.electronAPI?.isElectron,
+            hasDirectoryBridge:
+              typeof window.electronAPI?.readDirectory === "function",
+          }))
+        )
+        .toEqual({ isElectron: true, hasDirectoryBridge: true });
+    } finally {
+      await electronApp?.close().catch(() => {});
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- stop publishing unsupported AppImages and bump the release candidate to 0.6.0-rc.3
- fix the installed `/usr/bin/video-swarm` launcher so it resolves Debian's update-alternatives symlink chain
- add a fail-fast Debian post-install hook that leaves `chrome-sandbox` root-owned with mode `4755`
- install and launch the exact generated `.deb` in CI without sandbox-bypass switches
- align release workflows, issue templates, release notes, README, and architecture guidance with the Debian-only Linux policy
- declare the ALSA runtime dependency explicitly

## Validation

- `npm test -- --run` — 1,064 passed, 21 skipped
- `npm run test:electron-abi` — 51 passed
- `npm run lint`
- `npm run vite:build`
- `npm run test:electron-smoke` — 3 passed, installed-package test skipped locally as designed
- local `.deb` build and archive audit — version/architecture/dependencies, fail-fast postinst, one Debian artifact, no AppImage

CI performs the remaining acceptance check by installing the package as root and launching `/usr/bin/video-swarm` as a non-root user with Chromium sandboxing enabled.